### PR TITLE
Implement Frontend and Endpoints.

### DIFF
--- a/server/frontend/dist/index.html
+++ b/server/frontend/dist/index.html
@@ -3,48 +3,52 @@
   <head>
     <meta charset="utf-8">
     <title>Shotgrid Integration</title>
-    <style>
-
-      html, body {
-        padding: 20px;
-        background: #2c313a;
-        color: #ccc;
-        font-family: sans-serif;
-      }
-
-      fieldset {
-        border-color: #252323;
-        margin-bottom: 20px;
-      }
-
-    </style>
+    <link rel="stylesheet" type="text/css" href="shotgrid-addon.css">
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
-
   </head>
 
   <body>
-    <h1>Shotgrid Integration</h1>
-    <p> Via this page you can trigger certain events that will interact with Shotgird and gather some stats about the integration.</p>
+    <h1>Shotgrid Sync</h1>
+    <p> From this page you can Import projects from Shotgrid or trigger a project Sync!</p>
+    <div class="shotgrid-addon-container">
+        <div class="shotgrid-addon-block">
+            <h2>Import a New Project</h2>
+            <p> To be able to import a project from Shotgrid, there are two minimum requirements</p>
+            <ul>
+                <li> The Project name cannot contain spaces. </li>
+                <li> The Project has to have a code.
+            </ul>
+            
+            <p> If the above criteria isn't met, they won't show in the dropdown, so make sure they are correctly configured </p>
 
-    <h3> Prepare Project on Shotgrid</h3>
-    <p> Ensure all the required data is present in Shotgrid, greyed out fields means they are not really set on Shotgrid, use <a href=#create_attributes>Create attributes </a> below to fix that.
-    <button id="prepare-shotgrid-project"> Prepare Shotgrid Project </button>
+            <div class="project-creation">
+                <div class="project-item">
+                    <label for="new-shotgrid-projects-select">Choose a Shotgrid Project:</label>
+                    <select name="new-shotgrid-projects" id="new-shotgrid-projects-select">
+                        <option value="" id="fetching-shotgrid-option">Fetching Shotgrid projects...</option>
+                    </select>
+                </div>
+            </div>
 
-    <h3> Create Custom Attributes </h3>
-    <p> Ensure that all the Ayon specific attributes are present in Shotgrid </p>
-    <details>
-      <summary>List of Custom Fields in Shotgrid</summary>
-      <ul>
-        <li>ay_url</li>
-        <li>...</li>
-      </ul>
-    </details>
-    <button id="sg-create-custom-attributes"> Create Custom Attributes </button>
-    
-    <h3> Perform a full Sync </h3>
-    <p> Compare the Shotgrid Project with the Ayon one, and backfill any missing data. </p>
-    <button id="sg-create-custom-attributes"> Create Custom Attributes </button>
+            <button id="sg-import-shotgrid-project" disabled>Import Project...</button>
+        </div>
+        <div class="shotgrid-addon-block">
+            <h2>Manage Existing Project</h2>
+            <p>Compare the Shotgrid Project with the Ayon one, and backfill any missing data from Shotgrid.</p>
+            <p>Currently we sync: Episodes, Sequences, Shots and Tasks.</p>
+            <div class="project-item">
+                <label for="manage-shotgrid-projects-select">Dropdown of already imported Projects:</label>
+                <select name="shotgrid-projects" id="manage-shotgrid-projects-select">
+                    <option value="">Choose a project to Sync...</option>
+                </select>
+            </div>
 
+            <button id="sg-sync-from-shotgrid" disabled> Sync Shotgrid Project</button>
+        </div>
+    </div>
+    <p id="call-result"> </p>
+
+    <script type="text/javascript" src="shotgrid-addon.js"></script>
   </body>
 </html>
 

--- a/server/frontend/dist/shotgrid-addon.css
+++ b/server/frontend/dist/shotgrid-addon.css
@@ -1,0 +1,54 @@
+body {
+    padding: 0 20px;
+    background: #21252b;;
+    color: #ccc;
+    font-family: sans-serif;
+}
+
+iframe > html {
+    border-radius: 5px;
+}
+
+fieldset {
+    border-color: #252323;
+    margin-bottom: 20px;
+}
+
+h2 {
+    margin-top: 40px;
+}
+
+button {
+    margin-top: 20px;
+}
+
+select {
+    margin-top: 10px;
+}
+
+.shotgrid-addon-container {
+    display:flex;
+    flex-flow: row nowrap;
+}
+
+.shotgrid-addon-block {
+    /* padding-right: 20px; */
+}
+
+.shotgrid-addon-block:last-child{
+    border-left: 4px solid #2c313a;
+    padding-left: 20px;
+}
+
+.project-creation {
+    display:flex;
+    flex-flow: column nowrap;
+}
+
+.project-item {
+    display:flex;
+    flex-flow: column nowrap;
+    margin-right: 20px;
+    margin-bottom: 20px;
+    max-width: 415px;
+}

--- a/server/frontend/dist/shotgrid-addon.js
+++ b/server/frontend/dist/shotgrid-addon.js
@@ -1,0 +1,248 @@
+var addonName = null
+var addonVersion = null
+var accessToken = null
+var projectName = null
+var addonScope = null
+
+const init = () => {
+ /*
+When the addon page is loaded, it receive a message with context and
+additional data (accessToken, addon version...). When the context is changed, 
+a message is re-broadcasted, so the page can react to changes in selection etc.
+ */
+
+  window.onmessage = (e) => {
+    const context = e.data.context
+    addonName = e.data.addonName
+    addonVersion = e.data.addonVersion
+    accessToken = e.data.accessToken
+    addonScope = e.data.scope
+
+    getSyncableProjects();
+    getShotgridProjects();
+  } // end of window.onmessage
+} // end of init
+
+const importProject = (projectName, projectCode) => {
+  /* Trigger an event dispatching for a project creation/import.
+
+    Given a `projectName` and `projectCode` make an API call to the custom API
+    endpoint `create-project` which will create a `shotgrid.event` to be handled
+    by any listening processor.
+  */
+  if (projectName) {
+    const url = `/api/addons/${addonName}/${addonVersion}/create-project`
+    const headers = {"Authorization": `Bearer ${accessToken}`}
+    axios
+      .post(url, data={"project_name": `${projectName}`, "project_code": `${projectCode}`}, {headers})
+      .then((response) => {
+        const msg = `Create response data: ${response.data}` 
+        document.querySelector("#call-result").innerHTML = msg
+      })
+  }
+}
+
+const syncProject = (projectName) => {
+  /* Trigger an event dispatching for a project syncronization.
+
+    Given a `projectName` make an API call to the custom API endpoint
+    `sync-from-shotgrid` which will create a `shotgrid.event` to be handled
+    by any listening processor.
+  */
+  if (projectName) {
+    const url = `/api/addons/${addonName}/${addonVersion}/sync-from-shotgrid/${projectName}`
+    const headers = {"Authorization": `Bearer ${accessToken}`}
+
+    axios
+      .get(url, {headers})
+      .then((response) => {
+        const msg = `Create response data: ${response.data}` 
+        document.querySelector("#call-result").innerHTML = msg
+      })
+  }
+}
+
+const getImportableProjects = async () => {
+  /* Retrieve projects from Shotgrid
+
+    Via the custom `get-importable-projects` endpoint, receive an array
+    of projects that can be imported from Shotgrid, i.e. have a valid `name` and
+    `code`.
+  */
+  const headers = {"Authorization": `Bearer ${accessToken}`};
+
+  const response = await axios.get(
+    `/api/addons/${addonName}/${addonVersion}/get-importable-projects`,
+    {headers}
+  );
+  return response.data
+}
+
+const getShotgridProjects = () => {
+  /* Retrieve projects from Shotgrid and populate the Import dropdown.
+
+    Relies in `getImportableProjects` to get the projects, then we ensure the
+    fetched projects contain all needed information and populate the Import 
+    dropdown.
+  */
+  getImportableProjects()
+  .then((shotgridProjects) => {
+    const foundProjects = []
+    if (shotgridProjects) {
+      shotgridProjects.forEach((el) => {
+        if (el.projectName && el.projectCode && el.ayonId == null) {
+          let projectOption = document.createElement("option")
+          projectOption.innerHTML = `${el.projectName} (${el.projectCode}) - Shotgrid ID: ${el.shotgridId}`
+          projectOption.setAttribute("value", `${el.projectName}`)
+          projectOption.setAttribute("data-project-name", `${el.projectName}`)
+          projectOption.setAttribute("data-project-code", `${el.projectCode}`)
+          foundProjects.push(projectOption)
+        }
+      })
+    }
+    if (foundProjects) {
+      populateImportDropdown(foundProjects);
+    }
+    return foundProjects
+  });
+}
+
+
+const populateImportDropdown = (projectsArray) => {
+  /* Given a non-empty array of projects, add the them to the Select Dropdwon
+    Also enable the "Sync Shotgrid Project" button when choosing a valid option or
+    removing it when its not.
+  */
+  
+  let projectsImportPlaceholderOption = document.getElementById("fetching-shotgrid-option")
+
+  if (projectsArray) {
+    projectsImportPlaceholderOption.innerHTML = "Choose a Project to Import and Sync..."
+    let projectsImportSelect = document.getElementById("new-shotgrid-projects-select")
+    let projectsImportButton= document.getElementById("sg-import-shotgrid-project")
+
+    projectsArray.forEach((projectOption) => {
+      projectsImportSelect.appendChild(projectOption)
+    });
+
+    projectsImportSelect.addEventListener('change', () => {
+        let syncProjectButton = document.getElementById("sg-sync-from-shotgrid")
+
+        if (projectsImportSelect.selectedOptions[0].value) {
+          projectsImportButton.disabled = false
+          projectsImportButton.addEventListener("click", importProjectCallback);
+
+        } else {
+          projectsImportButton.disabled = true
+          projectsImportButton.removeEventListener("click", importProjectCallback);
+        }
+    });
+  } else {
+    projectsImportPlaceholderOption.innerHTML = "Unable to find valid Projects."
+  };
+}
+
+const importProjectCallback = () => {
+  /* Trigger the Addon API endpoint to Sync a project.
+    Named function so we can remove it from the event handler.
+  */
+  let projectsImportSelect = document.getElementById("new-shotgrid-projects-select")
+  let projectName = projectsImportSelect.selectedOptions[0].getAttribute("data-project-name");
+  let projectCode = projectsImportSelect.selectedOptions[0].getAttribute("data-project-code");
+
+  if (projectName) {
+    importProject(projectName, projectCode);
+  }
+}
+
+
+const getSyncableProjects = () => {
+  /* Query Ayon for all existing projects that have the shotgridID field not null
+    and append them to the Sync projects dropdown. 
+  */
+  axios({
+    url: '/graphql',
+    headers: {"Authorization": `Bearer ${accessToken}`},
+    method: 'post',
+    data: {
+      query: `
+        query ActiveProjects {
+          projects {
+            edges {
+              node {
+                attrib {
+                  shotgridId
+                }
+                active
+                code
+                name
+              }
+            }
+          }
+        }
+        `
+    }
+  }).then((result) => {
+    const foundProjects = []
+    if (result.data) {
+      if (result.data.data.projects.edges) {
+        result.data.data.projects.edges.forEach((el) => {
+          if (el.node.attrib.shotgridId) {
+            let projectOption = document.createElement("option")
+            projectOption.innerHTML = `${el.node.name} (${el.node.code}) - Shotgrid ID: ${el.node.attrib.shotgridId}`
+            projectOption.setAttribute("value", `${el.node.name}`)
+            foundProjects.push(projectOption)
+          }
+        })
+      }
+    }
+    if (foundProjects) {
+      populateSyncDropdown(foundProjects);
+    }
+    return foundProjects
+  });
+}
+
+const populateSyncDropdown = (projectsArray) => {
+  /* Given a non-empty array of projects, add the them to the Select Dropdwon
+    Also enable the "Sync Shotgrid Project" button when choosing a valid option or
+    removing it when its not.
+  */
+  if (projectsArray) {
+    let projectsSyncSelect = document.getElementById("manage-shotgrid-projects-select");
+
+    projectsArray.forEach((projectOption) => {
+      projectsSyncSelect.appendChild(projectOption)
+    });
+
+    projectsSyncSelect.addEventListener('change', () => {
+        let syncProjectButton = document.getElementById("sg-sync-from-shotgrid")
+
+        if (projectsSyncSelect.selectedOptions[0].value) {
+          syncProjectButton.disabled = false
+          syncProjectButton.addEventListener("click", syncProjectCallback);
+
+        } else {
+          syncProjectButton.disabled = true
+          syncProjectButton.removeEventListener("click", syncProjectCallback);
+        }
+    });
+    
+  };
+}
+
+const syncProjectCallback = () => {
+  /* Trigger the Addon API endpoint to Sync a project.
+    Named function so we can remove it from the event handler.
+  */
+  let projectsSyncSelect = document.getElementById("manage-shotgrid-projects-select");
+  let projectName = projectsSyncSelect.selectedOptions[0].value
+
+  if (projectName) {
+    syncProject(`${projectName}`);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+ init()
+})


### PR DESCRIPTION
This commit implements the Addon frontend which can be accessed in the Ayon Server > Settings > Shotgrid Sync page.

The frontend offers two actions, import and sync.
For Importing, it will, via the Shotgrid REST API implemented in the callback for the `get-importable-projects` endpoint, fetch the projects that are not a template, and will allow the person to choose from a drodown the project to import, by clicking the "Import Project" button.

For Syncronizing, a call to the Ayon server GraphQl API is performed, and we only display the projects that have the `shotgridId` attribute filled, once the person picks a show and click the button "Sync Shotgrid Project".

In both instances, upong clicking the button, will dispacth an event of the topic `shotgrid.event` which has to be handled by a `processor` respectively, which are not included in this commit, these are catched by the `create-project` and `sync-from-shotgrid` endpoints.

The CSS and Javascript have been split in separate files.