### PR TITLE
fix sg project attrs constant

### DIFF
--- a/services/processor/processor/lib/constants.py
+++ b/services/processor/processor/lib/constants.py
@@ -29,6 +29,11 @@ SG_PROJECT_ATTRS = {
         "name": "Ayon Server URL",
         "type": "text",
         "sg_field": CUST_FIELD_CODE_URL,
+    },
+    "ayon_project_name": {
+        "name": "Ayon Project Name",
+        "type": "text",
+        "sg_field": CUST_FIELD_CODE_NAME
     }
 }
 


### PR DESCRIPTION
While syncing SG project we faced the issue with ayon project name. Ayon tried to get field "sg_ayon_project_name" from SG Project that was not set before by "create_ay_fields_in_sg_project" method