### PR TITLE
New `settings.shotgrid_project_code_field` field

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -144,7 +144,8 @@ class ShotgridAddon(BaseServerAddon):
         elif not all((
             addon_settings.shotgrid_server,
             addon_settings.shotgrid_script_name,
-            addon_settings.shotgrid_api_key
+            addon_settings.shotgrid_api_key,
+            addon_settings.shotgrid_project_code_field
         )):
             logging.error("Missing data in the addon settings.")
             return
@@ -173,7 +174,6 @@ class ShotgridAddon(BaseServerAddon):
             "Accept": "application/vnd+shotgun.api3_array+json"
         }
 
-
         shotgrid_projects = requests.get(
             f"{shotgrid_url}/api/v1/entity/projects/",
             headers=request_headers
@@ -189,7 +189,7 @@ class ShotgridAddon(BaseServerAddon):
                     data=json.dumps({
                         "fields": [
                             "name",
-                            "code",
+                            addon_settings.shotgrid_project_code_field,
                             "sg_ayon_sync_status",
                         ]
                     }),
@@ -205,7 +205,9 @@ class ShotgridAddon(BaseServerAddon):
 
                 sg_projects.append({
                     "projectName": sg_project["attributes"].get("name"),
-                    "projectCode": sg_project["attributes"].get("code"),
+                    "projectCode": sg_project["attributes"].get(
+                        addon_settings.shotgrid_project_code_field
+                    ),
                     "shotgridId": sg_project["id"],
                     "ayonId": sg_project["attributes"].get("sg_ayon_id"),
                     "ayonAutoSync": sg_project["attributes"].get("sg_ayon_auto_sync"),

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -32,7 +32,10 @@ class ShotgridSettings(BaseSettingsModel):
         "",
         title="Shotgrid API Key"
     )
-
+    shotgrid_project_code_field: str = Field(
+        "",
+        title="Shotgrid field for the project Code i.e.: `code`, `sg_code`, `sg_internal_code`."
+    )
     service_settings: ShotgridServiceSettings = Field(
         default_factory=ShotgridServiceSettings,
         title="Service settings",
@@ -41,6 +44,8 @@ class ShotgridSettings(BaseSettingsModel):
 
 DEFAULT_VALUES = {
     "shotgrid_server": "",
+    "shotgrid_script_name": "Ayon Connector",
+    "shotgrid_project_code_field": "code",
     "service_settings": {
         "username": "",
         "api_key": ""

--- a/services/processor/processor/handlers/update_from_shotgrid.py
+++ b/services/processor/processor/handlers/update_from_shotgrid.py
@@ -4,15 +4,10 @@ Handle Events originated from Shotgrid.
 from nxtools import logging
 
 from processor.lib.update_from_shotgrid import UpdateFromShotgrid
-from processor.lib.constants import CUST_FIELD_CODE_ID, CUST_FIELD_CODE_AUTO_SYNC
+from processor.lib.constants import CUST_FIELD_CODE_AUTO_SYNC
 from processor.lib.utils import get_sg_project_by_id
 
 REGISTER_EVENT_TYPE = ["shotgrid-event"]
-FIELDS_WE_CARE = [
-    "code",
-    "name",
-    CUST_FIELD_CODE_ID,
-]
 
 
 def process_event(


### PR DESCRIPTION
Since it seems not all SG instances have the `code` field for projects, a new setting on the addon (which defaults to `code`) allows the person to define which field in shotgrid to use as `code` to create projects in Ayon.