### PR TITLE
`processor` Ensure we use correct project code field

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -70,6 +70,8 @@ class ShotgridAddon(BaseServerAddon):
         project_name,
         description=None
     ):
+        addon_settings = await self.get_studio_settings()
+
         event_id = await dispatch_event(
             "shotgrid.event",
             sender=socket.gethostname(),
@@ -81,6 +83,7 @@ class ShotgridAddon(BaseServerAddon):
                 "action": action,
                 "user_name": user_name,
                 "project_name": project_name,
+                "project_code_field": addon_settings.shotgrid_project_code_field,
             },
         )
         logging.info(f"Dispatched event {event_id}")
@@ -91,6 +94,8 @@ class ShotgridAddon(BaseServerAddon):
         user: UserEntity = Depends(dep_current_user),
         project_name: str = Depends(dep_project_name),
     ):
+        addon_settings = await self.get_studio_settings()
+
         await self._dispatch_shotgrid_event(
             "sync-from-shotgrid",
             user.name,
@@ -111,6 +116,7 @@ class ShotgridAddon(BaseServerAddon):
         else:
             request_body = json.loads(request_body)
 
+        addon_settings = await self.get_studio_settings()
         project_name = request_body.get("project_name")
         project_code = request_body.get("project_code")
 
@@ -130,6 +136,7 @@ class ShotgridAddon(BaseServerAddon):
                     "user_name": user.name,
                     "project_name": project_name,
                     "project_code": project_code,
+                    "project_code_field": addon_settings.shotgrid_project_code_field,
                     "description": description,
                 },
             )

--- a/server/frontend/dist/shotgrid-addon.js
+++ b/server/frontend/dist/shotgrid-addon.js
@@ -77,11 +77,18 @@ const getImportableProjects = async () => {
 
 const getShotgridData = () => {
   /* Wrapper function to trigger the fetch of Shotgrid data.*/
-    let projectsSyncSelect = document.getElementById("manage-shotgrid-projects-select");
-    projectsSyncSelect.children[0].innerText = "Fetching data from Shotgrid...";
+    default_option = document.createElement('option');
+    default_option.text = "Fetching data from Shotgrid..."
 
+    let projectsSyncSelect = document.getElementById("manage-shotgrid-projects-select");
+    projectsSyncSelect.options.length = 0
+    projectsSyncSelect.appendChild(default_option)
+
+    default_option2 = document.createElement('option');
+    default_option2.text = "Fetching data from Shotgrid..."
     let projectsImportSelect = document.getElementById("new-shotgrid-projects-select")
-    projectsImportSelect.children[0].innerText = "Fetching data from Shotgrid...";
+    projectsImportSelect.options.length = 0
+    projectsImportSelect.appendChild(default_option2)
 
     getSyncableProjects();
     getShotgridProjects();
@@ -122,12 +129,12 @@ const populateImportDropdown = (projectsArray) => {
     Also enable the "Sync Shotgrid Project" button when choosing a valid option or
     removing it when its not.
   */
-  
-  let projectsImportPlaceholderOption = document.getElementById("fetching-shotgrid-option")
-
-  if (projectsArray) {
-    projectsImportPlaceholderOption.innerHTML = "Choose a Project to Import and Sync..."
     let projectsImportSelect = document.getElementById("new-shotgrid-projects-select")
+    projectsImportSelect.options.length = 0;
+  if (projectsArray) {
+    default_option = document.createElement('option');
+    default_option.text = "Choose a Project to Import and Sync..."
+    projectsImportSelect.appendChild(default_option)
     let projectsImportButton= document.getElementById("sg-import-shotgrid-project")
 
     projectsArray.forEach((projectOption) => {
@@ -147,7 +154,9 @@ const populateImportDropdown = (projectsArray) => {
         }
     });
   } else {
-    projectsImportPlaceholderOption.innerHTML = "Unable to find valid Projects."
+    default_option = document.createElement('option');
+    default_option.text = "Unable to find valid Projects."
+    projectsImportSelect.appendChild(default_option)
   };
 }
 
@@ -205,11 +214,15 @@ const getSyncableProjects = () => {
         })
       }
     }
+
     if (foundProjects) {
       populateSyncDropdown(foundProjects);
     } else {
       let projectsSyncSelect = document.getElementById("manage-shotgrid-projects-select");
-      projectsSyncSelect.children[0].innerText = "No projects to Sync, import some first.";
+      projectsSyncSelect.options.length = 0;
+      default_option = document.createElement('option');
+      default_option.text = "No projects to Sync, import some first."
+      projectsSyncSelect.appendChild(default_option);
     }
     return foundProjects
   });
@@ -222,6 +235,10 @@ const populateSyncDropdown = (projectsArray) => {
   */
   if (projectsArray) {
     let projectsSyncSelect = document.getElementById("manage-shotgrid-projects-select");
+    projectsSyncSelect.options.length = 0;
+    default_option = document.createElement('option');
+    default_option.text = "Select a project to Sync..."
+    projectsSyncSelect.appendChild(default_option);
 
     projectsArray.forEach((projectOption) => {
       projectsSyncSelect.appendChild(projectOption)
@@ -239,7 +256,6 @@ const populateSyncDropdown = (projectsArray) => {
           syncProjectButton.removeEventListener("click", syncProjectCallback);
         }
     });
-    
   };
 }
 

--- a/services/processor/processor/handlers/sync_from_shotgrid.py
+++ b/services/processor/processor/handlers/sync_from_shotgrid.py
@@ -28,6 +28,8 @@ def process_event(
         logging.error("Can't Sync a project without a name!")
         return
 
+    project_code_field = kwargs.get("project_code_field", "code")
+
     try:
         shotgrid_project = get_sg_project_by_name(
             shotgrid_session,
@@ -36,6 +38,7 @@ def process_event(
     except ValueError:
         logging.error(f"Could not find {project_name} in Shotgrid!")
         return
+
 
     try:
         ayon_project = get_project(project_name)
@@ -49,7 +52,8 @@ def process_event(
 
     try:
         # Trigger a one time Sync.
-        sg_sync = SyncFromShotgrid(shotgrid_session, project_name, log=logging)
+        project_code_field = kwargs.get("project_code_field", "code")
+        sg_sync = SyncFromShotgrid(shotgrid_session, project_name, project_code_field, log=logging)
         sg_sync.sync_to_ayon()
     except Exception as e:
         logging.error(f"Shotgrid Sync of project {project_name} failed!")

--- a/services/processor/processor/lib/sync_from_shotgrid.py
+++ b/services/processor/processor/lib/sync_from_shotgrid.py
@@ -46,7 +46,7 @@ class IdsMapping(object):
 class SyncFromShotgrid:
     """Helper for sync project from Shotgrid."""
 
-    def __init__(self, session, project_name, log=None):
+    def __init__(self, session, project_name, project_code_field, log=None):
         self._log = log
         self._sg_session = session
 
@@ -59,11 +59,17 @@ class SyncFromShotgrid:
             self.log.error(msg)
             raise ValueError(msg)
 
+        if project_code_field:
+            self.project_code_field = project_code_field
+        else:
+            self.project_code_field = "code"
+
         self._entity_hub = EntityHub(project_name)
 
         self._sg_project = get_sg_project_by_name(
             self._sg_session,
-            project_name
+            project_name,
+            custom_fields=[self.project_code_field]
         )
         self._check_shotgrid_project()
 
@@ -97,6 +103,7 @@ class SyncFromShotgrid:
     def sync_to_ayon(self, preset_name=None):
         self.log.info("Started Ayon Syncronization with Shotgrid.")
         self.log.info(f"Project Name: {self._ay_project['name']}")
+        self.log.info(f"The Shotgrid field for project code is: {self.project_code_field}")
 
         sync_start_time = time.perf_counter()
         self.log.info("Loading Entities data from Ayon.")
@@ -126,6 +133,8 @@ class SyncFromShotgrid:
         ) = get_sg_entities(
             self._sg_session,
             self._sg_project,
+            custom_fields=[self.project_code_field],
+            project_code_field=self.project_code_field
         )
 
         prev_step_time = sync_step_time


### PR DESCRIPTION
The Shotgrid addon allows to specify the Shotgrid field for `code`, but we weren't really using it or passing it to the `SyncFromShotgrid` class, we now do allwing the Sync where the code field is not `code`.