### PR TITLE
`server.frontend` - Imporved UX for the Addon frontend

### DIFF
--- a/server/frontend/dist/index.html
+++ b/server/frontend/dist/index.html
@@ -11,47 +11,31 @@
     <h1>Shotgrid Sync</h1>
     <p>
         From this page you can Import projects from Shotgrid or trigger a project Sync!<br>
-        In order for the below to work, a <b><code>ShotgridProcessor</code> service must be running</b><br>
-        But first we need to fetch data from Shotgrid:
+        In order for the Syncronization to work, a <b><code>ShotgridProcessor</code> <a href="/services">service</a> must be running</b>, this page will only create <a href="/events"> events (with the topic: "shotgrid.event") </a> for the processor to handle.
     </p>
+    <p>To be able to import a project from Shotgrid, there are two minimum requirements on Shotgrid:</p>
+        <ul>
+            <li> The Project name cannot contain spaces. </li>
+            <li> The Project has to have a code, has to be lowercase and cannot start with a number. (You can choose what the field code is in the Addon Settings), </li>
+        </ul>
+    <p>If the above criteria isn't met, the Synchronization button will be greyed out.</p>
+    <p>But first we need to fetch data from Shotgrid, press the button below:</p>
+    <button id="populate-table-button"  class="populate-table-button" onclick="populateTable();">Populate Table</button>
 
-    <button id="sg-fetch-data" onclick="getShotgridData();">Fetch data from Shotgrid</button>
-    <div class="shotgrid-addon-container">
-        <div class="shotgrid-addon-block">
-            <h2>Import a New Project</h2>
-            <p> To be able to import a project from Shotgrid, there are two minimum requirements on Shotgrid:</p>
-            <ul>
-                <li> The Project name cannot contain spaces. </li>
-                <li> The Project has to have a code. (You can choose what the field code is in the Addon Settings) </li>
-            </ul>
-            <p> If the above criteria isn't met, they won't show in the dropdown, so make sure they are correctly configured.</p>
+    <table id="sg-addon-projects-table">
+        <thead id="sg-addon-projects-table-header">
+            <tr>
+                <th>Name</th>
+                <th>Code</th>
+                <th>In AYON?</th>
+                <th>In Shotgrid?</th>
+                <th>Syncronize</th>
+            </tr>
+        </thead>
+        <tbody class="sg-addon-projects-table-body" id="sg-addon-projects-table-body">
+        </tbody>
+    </table>
 
-            <div class="project-creation" display="none">
-                <div class="project-item">
-                    <label for="new-shotgrid-projects-select">Choose a Shotgrid Project:</label>
-                    <select name="new-shotgrid-projects" id="new-shotgrid-projects-select">
-                        <option value="" id="fetching-shotgrid-option">Please press the "Fetch data from Shotgrid" above.</option>
-                    </select>
-                </div>
-            </div>
-
-            <button id="sg-import-shotgrid-project" disabled>Import Selected Project...</button>
-
-        </div>
-        <div class="shotgrid-addon-block">
-            <h2>Manage Existing Project</h2>
-            <p>Compare the Shotgrid Project with the Ayon one, and backfill any missing data from Shotgrid.</p>
-            <p>Currently we sync: Episodes, Sequences, Shots and Tasks.</p>
-            <div class="project-item">
-                <label for="manage-shotgrid-projects-select">Already imported Projects:</label>
-                <select name="shotgrid-projects" id="manage-shotgrid-projects-select">
-                    <option value="">Please press the "Fetch data from Shotgrid" above.</option>
-                </select>
-            </div>
-
-            <button id="sg-sync-from-shotgrid" disabled> Sync Shotgrid Project</button>
-        </div>
-    </div>
     <p id="call-result"> </p>
 
     <script type="text/javascript" src="shotgrid-addon.js"></script>

--- a/server/frontend/dist/shotgrid-addon.css
+++ b/server/frontend/dist/shotgrid-addon.css
@@ -18,37 +18,62 @@ h2 {
     margin-top: 40px;
 }
 
-button {
-    margin-top: 20px;
-}
-
 select {
     margin-top: 10px;
 }
 
-.shotgrid-addon-container {
-    display:flex;
-    flex-flow: row nowrap;
+table {
+  table-layout: fixed;
+  width: 100%;
+  border-collapse: collapse;
+  border: 4px solid #2C313A;
+  margin-top: 25px;
 }
 
-.shotgrid-addon-block {
-    /* padding-right: 20px; */
+thead {
+    text-align: left;
+    background-color: #2C313A;
 }
 
-.shotgrid-addon-block:last-child{
-    border-left: 4px solid #2c313a;
-    padding-left: 20px;
+thead th:nth-child(1) {
+  width: 20%;
 }
 
-.project-creation {
-    display:flex;
-    flex-flow: column nowrap;
+thead th:nth-child(2) {
+  width: 20%;
 }
 
-.project-item {
-    display:flex;
-    flex-flow: column nowrap;
-    margin-right: 20px;
-    margin-bottom: 20px;
-    max-width: 415px;
+thead th:nth-child(3) {
+  width: 20%;
 }
+
+thead th:nth-child(4) {
+  width: 20%;
+}
+
+thead th:nth-child(5) {
+  width: 35%;
+}
+
+tbody td {
+  text-align: left;
+  border: 3px solid #2C313A;
+}
+
+th,
+td {
+  border: 3px solid #2C313A;
+}
+
+tbody tr:nth-child(odd) {
+  background-color: var(--gray-50);
+}
+
+tbody tr:nth-child(even) {
+  background-color: #2C313A;
+}
+
+.populate-table-button {
+    margin-top: 20px;
+}
+


### PR DESCRIPTION
This commit replaces the current UI for the "Shotgrid Sync" page, but it also removes logic previously done behind addon endpoints; this improves the code by reducing the redundant logic and the latency between the actions and the UI changes.

The interface has been changed to also be a table of all projects in both AYON and Shotgrid with a column that tells the user if they exists in AYON and/or Shotgrid, this is now all done in Javascript, which makes the endpoint `"get-importable-projects"` redundant.

Another column "Syncronize" whith a button that will trigger the dispatch of the "shotgrid.event" that the processor picks up, this makes endpoint `"sync-from-shotgrid/{project_name}"` redundant.

A screenshot of the new UI:
![image](https://github.com/ynput/ayon-shotgrid/assets/1800151/d634611e-5b67-455b-90b0-69ce1cf04c78)
