### PR TITLE
`server` - Ensure we use the formatted SG url

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -168,7 +168,7 @@ class ShotgridAddon(BaseServerAddon):
 
 
         shotgrid_credentials_token = requests.post(
-            f"{addon_settings.shotgrid_server}/api/v1/auth/access_token",
+            f"{shotgrid_url}/api/v1/auth/access_token",
             data={
                 "client_id": f"{addon_settings.shotgrid_script_name}",
                 "client_secret": f"{addon_settings.shotgrid_api_key}",


### PR DESCRIPTION
When we input a Shotgrid url with trailing slashes in the AYON settings, we make sure we remove any trailign slash and space, but we weren't actually using the stripped url, this commit ensures we use it.