### PR TITLE
`client` - Fix wrong method when collection SG session

### DIFF
--- a/client/ayon_shotgrid/plugins/publish/collect_shotgrid_entities.py
+++ b/client/ayon_shotgrid/plugins/publish/collect_shotgrid_entities.py
@@ -9,7 +9,7 @@ class CollectShotgridEntities(pyblish.api.ContextPlugin):
     """Collect shotgrid entities according to the current context."""
 
     order = pyblish.api.CollectorOrder + 0.499
-    label = "Collect Shotgrid Assets and Tasks."
+    label = "Collect Shotgrid Assets and Tasks"
 
     def process(self, context):
         if not context.data.get("shotgridSession"):

--- a/client/ayon_shotgrid/plugins/publish/collect_shotgrid_session.py
+++ b/client/ayon_shotgrid/plugins/publish/collect_shotgrid_session.py
@@ -8,7 +8,7 @@ class CollectShotgridSession(pyblish.api.ContextPlugin):
     """Collect shotgrid session using user credentials"""
 
     order = pyblish.api.CollectorOrder
-    label = "Collecting Shotgrid session."
+    label = "Collecting Shotgrid session"
 
     def process(self, context):
         user_login = os.getenv("AYON_SG_USERNAME")
@@ -17,23 +17,25 @@ class CollectShotgridSession(pyblish.api.ContextPlugin):
                 "Have you logged in into Ayon Tray > Shotgrid ?"
             )
 
-        self.log.info(
-            "Attempting to create the Shotgrid Session for user: {0}".format(
-                user_login
-            )
-        )
-
         shotgrid_module = context.data["openPypeModules"]["shotgrid"]
         shotgrid_url = shotgrid_module.get_sg_url()
 
+        self.log.info(
+            "Attempting to create the Shotgrid Session for user: {0} at {1}".format(
+                user_login,
+                shotgrid_url
+            )
+        )
+
         try:
-            sg_session = shotgrid_module.get_shotgrid_session(user_login)
+            sg_session = shotgrid_module.create_shotgrid_session(user_login)
             self.log.info("Succesfully logged in into the Shotgrid API.")
-        except Exception:
+        except Exception as e:
+            self.log.error("Failed to connect to Shotgrid.", exc_info=True)
             raise KnownPublishError(
-                "Could not connect to Shotgrid {} with user {}".format(
+                "Could not connect to Shotgrid {0} with user {1}.".format(
                     shotgrid_url,
-                    user_login
+                    user_login,
                 )
             )
 


### PR DESCRIPTION
The `collect_shotgrid_session` was using a wrong method to create the SG session, this commit ensures it uses the correct one `create_shotgrid_session`.

Also removed the trailing dot from the `pyblish` plugins name so it follows all the other plugins.