### PR TITLE
`server` - Update services image versions

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -29,8 +29,9 @@ class ShotgridAddon(BaseServerAddon):
     frontend_scopes: dict[str, Any] = {"settings": {}}
 
     services = {
-        "ShotgridProcessor": {"image": "ynput/ayon-shotgrid-processor:0.1.1"},
-        "ShotgridLeecher": {"image": "ynput/ayon-shotgrid-leecher:0.1.1"}
+        "ShotgridLeecher": {"image": "ynput/ayon-shotgrid-leecher:0.2.0"},
+        "ShotgridProcessor": {"image": "ynput/ayon-shotgrid-processor:0.2.0"},
+        "ShotgridTransmitter": {"image": "ynput/ayon-shotgrid-transmitter:0.2.0"},
     }
 
     def initialize(self):


### PR DESCRIPTION
Forgot to update the `services` section on the `server` addon to point to the newly released `0.2.0` versions of the docker images.