### PR TITLE
Release Version 0.2.2

### DIFF
--- a/server/frontend/dist/shotgrid-addon.js
+++ b/server/frontend/dist/shotgrid-addon.js
@@ -9,7 +9,7 @@ var ayonAPI = null
 
 const init = () => {
  /* When the addon page is loaded, it receive a message with context and
-  additional data (accessToken, addon version...). When the context is changed, 
+  additional data (accessToken, addon version...). When the context is changed,
   a message is re-broadcasted, so the page can react to changes in selection etc.  */
 
   window.onmessage = async (e) => {
@@ -146,7 +146,7 @@ const getShotgridProjects = async () => {
     .get(`${sgBaseUrl}/entity/projects?fields=*`, {
       headers: {
         'Authorization': `Bearer ${sgAuthToken}`,
-        'Accept': 'application/vnd+shotgun.api3_array+json'
+        'Accept': 'application/json'
       }
     })
     .then((result) => result.data.data)

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -13,7 +13,7 @@ import socket
 from typing import Any, Callable, Union
 
 import ayon_api
-from nxtools import logging
+from nxtools import logging, log_traceback
 import shotgun_api3
 
 
@@ -82,8 +82,7 @@ class ShotgridListener:
 
         except Exception as e:
             logging.error("Unable to get Addon settings from the server.")
-            logging.error(e)
-
+            log_traceback(e)
             raise e
 
         try:
@@ -95,7 +94,7 @@ class ShotgridListener:
             self.sg_session.connect()
         except Exception as e:
             logging.error("Unable to connect to Shotgrid Instance:")
-            logging.error(e)
+            log_traceback(e)
             raise e
 
         signal.signal(signal.SIGINT, self._signal_teardown_handler)
@@ -194,7 +193,7 @@ class ShotgridListener:
                     limit=50,
                 )
                 if events:
-                    logging.info(f"Query returned {len(events)} events.")
+                    logging.info(f"Parsing returned {len(events)} events.")
 
                     for event in events:
                         if not event:
@@ -209,6 +208,7 @@ class ShotgridListener:
 
             except Exception as err:
                 logging.error(err)
+                log_traceback(err)
 
             logging.info(
                 f"Waiting {self.shotgrid_polling_frequency} seconds..."
@@ -246,7 +246,8 @@ class ShotgridListener:
             [["id", "is", project_id]],
             fields=[self.sg_project_code_field]
         )
-        
+        logging.debug(f"Found Shotgrid Project {sg_project}")
+
         ayon_api.dispatch_event(
             "shotgrid.event",
             sender=socket.gethostname(),

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -67,7 +67,8 @@ def create_ay_entity_from_sg_event(sg_event, sg_project, sg_session, ayon_entity
     if sg_entity_dict.get(CUST_FIELD_CODE_ID):
         # Revived entity, check if it still in the Server
         ay_entity = ayon_entity_hub.get_or_query_entity_by_id(
-            sg_entity_dict.get(CUST_FIELD_CODE_ID)
+            sg_entity_dict.get(CUST_FIELD_CODE_ID),
+            ["task" if sg_entity_dict.get(SHOTGRID_TYPE_ATTRIB).lower() == "task" else "folder"]
         )
 
         if ay_entity:
@@ -93,7 +94,8 @@ def create_ay_entity_from_sg_event(sg_event, sg_project, sg_session, ayon_entity
     )
 
     ay_parent_entity = ayon_entity_hub.get_or_query_entity_by_id(
-        sg_parent_entity_dict.get(CUST_FIELD_CODE_ID)
+        sg_parent_entity_dict.get(CUST_FIELD_CODE_ID),
+        ["task" if sg_parent_entity_dict.get(CUST_FIELD_CODE_ID).lower() == "task" else "folder"]
     )
 
     if not ay_parent_entity:
@@ -163,9 +165,10 @@ def update_ayon_entity_from_sg_event(sg_event, sg_session, ayon_entity_hub):
 
     if not sg_entity_dict.get(CUST_FIELD_CODE_ID):
         logging.warning("Shotgrid Missing Ayon ID")
-
+    
     ay_entity = ayon_entity_hub.get_or_query_entity_by_id(
-        sg_entity_dict.get(CUST_FIELD_CODE_ID)
+        sg_entity_dict.get(CUST_FIELD_CODE_ID),
+        ["task" if sg_entity_dict.get(CUST_FIELD_CODE_ID).lower() == "task" else "folder"]
     )
 
     if not ay_entity:
@@ -221,7 +224,8 @@ def remove_ayon_entity_from_sg_event(sg_event, sg_session, ayon_entity_hub):
         raise ValueError("Shotgrid Missing Ayon ID")
 
     ay_entity = ayon_entity_hub.get_or_query_entity_by_id(
-        sg_entity_dict.get(CUST_FIELD_CODE_ID)
+        sg_entity_dict.get(CUST_FIELD_CODE_ID),
+        ["task" if sg_entity_dict.get(CUST_FIELD_CODE_ID).lower() == "task" else "folder"]
     )
 
     if not ay_entity:

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -528,8 +528,6 @@ def get_sg_project_enabled_entities(
     for sg_entity_type in AYON_SHOTGRID_ENTITY_TYPE_MAP:
         if sg_entity_type == "Project":
             continue
-        elif sg_entity_type == "__flat__":
-            continue
 
         is_entity_enabled = sg_project_schema.get(
             sg_entity_type, {}
@@ -538,7 +536,7 @@ def get_sg_project_enabled_entities(
         if is_entity_enabled:
             parent_field = project_navigation.get(sg_entity_type, None)
 
-            if parent_field:
+            if parent_field and parent_field != "__flat__":
                 project_entities.append((
                     sg_entity_type,
                     parent_field.replace(f"{sg_entity_type}.", "")

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -108,20 +108,6 @@ def create_ay_fields_in_sg_project(sg_session: shotgun_api3.Shotgun):
             field_properties=sg_field_properties
         )
 
-def create_ay_entities_in_sg(
-    project_entity: ProjectEntity,
-    sg_session: shotgun_api3.Shotgun,
-    shotgrid_project: dict
-):
-    """Ensure Shotgrid has all the Ayon Task and Folder types.
-
-    Args:
-        project_entity (ProjectEntity): The ProjectEntity for a given project.
-        sg_session (shotgun_api3.Shotgun): Shotgun Session object.
-        shotgrid_project (dict): The project owning the Tasks.
-    """
-    pass
-
 def create_sg_entities_in_ay(
     project_entity: ProjectEntity,
     sg_session: shotgun_api3.Shotgun,

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -40,8 +40,8 @@ class ShotgridTransmitter:
             self.sg_url = self.settings["shotgrid_server"]
 
             sg_secret = ayon_api.get_secret(self.settings["shotgrid_script_name"])
-            self.sg_script_name = shotgrid_secret.get("name")
-            self.sg_api_key = shotgrid_secret.get("value")
+            self.sg_script_name = sg_secret.get("name")
+            self.sg_api_key = sg_secret.get("value")
 
         except Exception as e:
             logging.error("Unable to get Addon settings from the server.")

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring addon version."""
-__version__ = "0.2.1"
+__version__ = "0.2.2"


### PR DESCRIPTION
* `services.transmitter` Fix variable for Secret. We were storing the secret to a variable, and then accessing it via another non existant one.

*  `frontend` Fix SG projects query headers. The REST API docs seems to have cahnged and no longer allow the previous `Accept` entry for the header, this now uses the common `application/json`.

* `ayon_shotgrid_hub` Fix AYON to Shotgrid Sync. The AYON to Shotgrid Sync was buggy, since it didn't account for missing (disabled) entities in Shotgrid, we now perform a check and raise before attempting to sync.

* `leecher` Better logging of exceptions. This commit prints the traceback of an exception, this will allow for easier debugging of potential issues.

* `ayon_shotgrid_hub` Fix update from Shotgrid. We weren't passing a required argument to the AYON entity hub to query entities by id, which this commit now does.

*  service.utils Fix SG __flat__ entities. In Shotgrid you can have entities that are not bound to anything in the
hierarchy (so they really are at a Project level), the previous fix didn't
really act on the SG entities, this commit now fixes by setting the parent
of the entity to "project" when one of them is `__flat__`.
