### PR TITLE
Release for 0.2.3

### DIFF
--- a/services/Makefile
+++ b/services/Makefile
@@ -23,7 +23,7 @@ default:
 	
 
 build:
-	docker build -t $(IMAGE) -f $(SERVICE)/Dockerfile .
+	docker build --network=host -t $(IMAGE) -f $(SERVICE)/Dockerfile .
 
 build-all:
 	$(foreach service,leecher processor transmitter, docker build -t ynput/ayon-shotgrid-$(service):$(ADDON_VERSION) -f $(service)/Dockerfile . &)
@@ -34,7 +34,7 @@ clean:
 	fi
 
 clean-build: clean
-	docker build --no-cache -t $(IMAGE) -f $(SERVICE)/Dockerfile .
+	docker build --network=host --no-cache -t $(IMAGE) -f $(SERVICE)/Dockerfile .
 
 dev:
 	-ln -s $(CURDIR)/shotgrid_common/* $(CURDIR)/$(SERVICE)

--- a/services/leecher/pyproject.toml
+++ b/services/leecher/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shotgrid-leecher"
-version = "0.1.1"
+version = "0.2.3"
 description = "Shotgrid Integration for Ayon"
 authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shotgrid-processor"
-version = "0.1.1"
+version = "0.2.3"
 description = "Shotgrid Integration for Ayon"
 authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -9,7 +9,7 @@ from constants import (
 
 from utils import get_sg_entities
 
-from nxtools import logging
+from nxtools import logging, log_traceback
 
 
 def match_shotgrid_hierarchy_in_ayon(entity_hub, sg_project, sg_session):
@@ -41,16 +41,16 @@ def match_shotgrid_hierarchy_in_ayon(entity_hub, sg_project, sg_session):
 
     while sg_entities_deck:
         (ay_parent_entity, sg_entity) = sg_entities_deck.popleft()
-        logging.debug(f"Processing {sg_entity})")
+        logging.debug(f"Processing {sg_entity} with parent {ay_parent_entity}")
 
         ay_entity = None
         sg_entity_sync_status = "Synced"
 
-        # Traverse the parent's children to see if it already exists in AYON.
-        for ay_child in ay_parent_entity.children:
-            if ay_child.name == sg_entity["name"]:
-                ay_entity = ay_child
-                logging.debug(f"Entity {ay_entity.name} exists in Ayon.")
+        ay_id = sg_entity.get("sg_ayon_id")
+        ay_type = ["task" if sg_entity.get("shotgridType") == "Task" else "folder"]
+
+        if ay_id:
+            ay_entity = entity_hub.get_or_query_entity_by_id(ay_id, ay_type)
 
         # If we couldn't find it we create it.
         if ay_entity is None:
@@ -59,27 +59,25 @@ def match_shotgrid_hierarchy_in_ayon(entity_hub, sg_project, sg_session):
                 ay_parent_entity,
                 sg_entity,
             )
-
-        # Make sure that if the AYON entity has a shotgridId attribute it matches SG.
-        logging.debug(f"Updating {ay_entity.name} <{ay_entity.id}>.")
-        shotgrid_id_attrib = ay_entity.attribs.get_attribute(
-            SHOTGRID_ID_ATTRIB
-        ).value
-
-        if not shotgrid_id_attrib:
-            ay_entity.attribs.set(
-                SHOTGRID_ID_ATTRIB,
-                sg_entity[SHOTGRID_ID_ATTRIB]
+        else:
+            logging.debug(
+                f"Entity {ay_entity.name} <{ay_entity.id}> exists in AYON. "
+                "Making sure the stored Shotgrid Data matches."
             )
-            ay_entity.attribs.set(
-                SHOTGRID_TYPE_ATTRIB,
-                sg_entity["type"]
-            )
-        elif str(shotgrid_id_attrib) != str(sg_entity[SHOTGRID_ID_ATTRIB]):
-            logging.error("Wrong Shotgrid ID in ayon record.")
-            sg_entity_sync_status = "Failed"
-            sg_project_sync_status = "Failed"
-            # TODO: How to deal with mismatches?
+
+            ay_shotgrid_id_attrib = ay_entity.attribs.get_attribute(
+                SHOTGRID_ID_ATTRIB
+            ).value
+
+            if ay_shotgrid_id_attrib != str(sg_entity[SHOTGRID_ID_ATTRIB]):
+                logging.error(
+                    f"The AYON entity {ay_entity.name} <{ay_entity.id}> has the "
+                    f"ShotgridId {ay_shotgrid_id_attrib}, while the Shotgrid ID "
+                    f"should be {sg_entity[SHOTGRID_ID_ATTRIB]}"
+                )
+                sg_entity_sync_status = "Failed"
+                sg_project_sync_status = "Failed"
+                # TODO: How to deal with mismatches?
 
         # Update SG entity with new created data
         sg_entity[CUST_FIELD_CODE_ID] = ay_entity.id
@@ -161,6 +159,16 @@ def _create_new_entity(entity_hub, parent_entity, sg_entity):
             entity_id=sg_entity[CUST_FIELD_CODE_ID],
             parent_id=parent_entity.id
         )
+
+    new_entity.attribs.set(
+        SHOTGRID_ID_ATTRIB,
+        sg_entity[SHOTGRID_ID_ATTRIB]
+    )
+
+    new_entity.attribs.set(
+        SHOTGRID_TYPE_ATTRIB,
+        sg_entity["type"]
+    )
 
     logging.debug(f"Created new entity: {new_entity.name} ({new_entity.id})")
     logging.debug(f"Parent is: {parent_entity.name} ({parent_entity.id})")

--- a/services/transmitter/pyproject.toml
+++ b/services/transmitter/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shotgrid-transmitter"
-version = "0.1.1"
+version = "0.2.3"
 description = "Shotgrid Integration for Ayon"
 authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring addon version."""
-__version__ = "0.2.2"
+__version__ = "0.2.3"


### PR DESCRIPTION
* `services` Use host's network in `Makefile` Updated the `Makefile` so we use the host's networ when building, since it was givin some errors when pulling from Alpine's repos.

* `services` Update `pyproject.toml` version number

* `ayon_shotgrid_hub` Fix sync from SG import and AYON entity search We were using the `log_traceback` without importing it.

* Bump to version 0.2.3
