### PR TITLE
Release Version 0.2.4

### DIFF
--- a/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_publish.py
+++ b/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_publish.py
@@ -1,4 +1,6 @@
 import os
+import platform
+
 import pyblish.api
 
 from openpype.pipeline.publish import get_publish_repre_path
@@ -49,6 +51,9 @@ class IntegrateShotgridPublish(pyblish.api.InstancePlugin):
                 "PublishedFile",
                 query_filters
             )
+
+            if platform.system() == "Windows":
+                local_path = local_path.replace("\\", "/")
 
             published_file_data = {
                 "project": sg_project,

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -236,8 +236,13 @@ class ShotgridListener:
         payload["created_at"] = payload["created_at"].isoformat()
 
         logging.info(description)
-        project_name = payload.get("project", {}).get("name", "Undefined")
-        project_id = payload.get("project", {}).get("id", "Undefined")
+
+        if payload.get("meta", {}).get("entity_type", "Undefined") == "Project":
+            project_name = payload.get("entity", {}).get("name", "Undefined")
+            project_id = payload.get("entity", {}).get("id", "Undefined")
+        else:
+            project_name = payload.get("project", {}).get("name", "Undefined")
+            project_id = payload.get("project", {}).get("id", "Undefined")
 
         logging.info(f"Event is from Project {project_name} ({project_id})")
 

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -9,7 +9,9 @@ from constants import (
     CUST_FIELD_CODE_AUTO_SYNC,
     CUST_FIELD_CODE_CODE,
     CUST_FIELD_CODE_ID,
-    CUST_FIELD_CODE_URL
+    CUST_FIELD_CODE_URL,
+    SHOTGRID_ID_ATTRIB,
+    SHOTGRID_TYPE_ATTRIB
 )
 
 from .match_shotgrid_hierarchy_in_ayon import match_shotgrid_hierarchy_in_ayon
@@ -219,6 +221,16 @@ class AyonShotgridHub:
                     CUST_FIELD_CODE_URL: ayon_api.get_base_url(),
                 }
             )
+            self._ay_project.project_entity.attribs.set(
+                SHOTGRID_ID_ATTRIB,
+                self._sg_project["id"]
+            )
+
+            self._ay_project.project_entity.attribs.set(
+                SHOTGRID_TYPE_ATTRIB,
+                "Project"
+            )
+            self._ay_project.commit_changes()
         else:
             logging.info(f"Project {self.project_name} ({self.project_code}) already exists in SG.")
 

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -107,7 +107,6 @@ def match_ayon_hierarchy_in_shotgrid(entity_hub, sg_project, sg_session):
             sg_entity = ay_parent_entity
 
         for ay_entity_child in entity_hub._entities_by_parent_id.get(ay_entity.id, []):
-            print(f"APPENDING {sg_entity} and {ay_entity_child}")
             ay_entities_deck.append((sg_entity, ay_entity_child))
 
     sg_session.update(
@@ -117,6 +116,16 @@ def match_ayon_hierarchy_in_shotgrid(entity_hub, sg_project, sg_session):
             CUST_FIELD_CODE_ID: entity_hub.project_name,
             CUST_FIELD_CODE_SYNC: sg_project_sync_status
         }
+    )
+
+    entity_hub.project_entity.attribs.set(
+        SHOTGRID_ID_ATTRIB,
+        sg_project["id"]
+    )
+
+    entity_hub.project_entity.attribs.set(
+        SHOTGRID_TYPE_ATTRIB,
+        "Project"
     )
 
 def _create_new_entity(ay_entity, sg_session, sg_project, sg_parent_entity):

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring addon version."""
-__version__ = "0.2.3"
+__version__ = "0.2.4"


### PR DESCRIPTION
* `ayon_shotgrid_hub` Store SG Project ID when creating from AYON When we create a SG Proejct from AYON we weren't storing the SG ID, which prevented the publishing workflow from working, this commit makes sure we store it when we create a project and after a successfully sync of "AYON->Shotgrid".

* `leecher` Fix Project type events When a SG event originates from a Project, the payload does not included the project itself in the "project" key, so we need to get it from the "entity" key.

* `client` Use forward slashes for PublishedFile Shotgrid's API requires paths to local storage to be with forward slashes, this commit ensures that if we are on Windows, we provide a path with the forward slashes.

* Bump Version 0.2.4