### PR TITLE
Release Version 0.2.5

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.poetry.dependencies]
 python = "^3.9"
-ayon-python-api = "^0.4"
+ayon-python-api = "^0.5"
 shotgun_api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.poetry.dependencies]
 python = "^3.9"
-ayon-python-api = "^0.1"
-shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.3.5" }
+ayon-python-api = "^0.4"
+shotgun_api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }

--- a/services/Makefile
+++ b/services/Makefile
@@ -29,7 +29,7 @@ build-all:
 	$(foreach service,leecher processor transmitter, docker build -t ynput/ayon-shotgrid-$(service):$(ADDON_VERSION) -f $(service)/Dockerfile . &)
 
 clean:
-	if docker images | grep $(IMAGE); then \
+	if docker images "$(IMAGE)"; then \
 		docker rmi $(IMAGE); \
 	fi
 

--- a/services/leecher/Dockerfile
+++ b/services/leecher/Dockerfile
@@ -1,5 +1,5 @@
 # In order for this Dockerfile to work it needs to be built from the `services` directory
-FROM python:alpine3.18
+FROM python:3.11-alpine3.18
 ENV PYTHONUNBUFFERED=1
 
 # Install python/pip

--- a/services/leecher/leecher/__main__.py
+++ b/services/leecher/leecher/__main__.py
@@ -4,6 +4,6 @@ from .listener import ShotgridListener
 
 
 if __name__ == "__main__":
-    shotgird_listener = ShotgridListener()
-    sys.exit(shotgird_listener.start_listening())
+    shotgrid_listener = ShotgridListener()
+    sys.exit(shotgrid_listener.start_listening())
 

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -224,7 +224,7 @@ class ShotgridListener:
         Returns:
             int: The Shotgrid Event ID.
         """
-        logging.info("Processing Shotgrid Event")
+        logging.info(f"Processing Shotgrid Event {payload}")
 
         description = f"Leeched {payload['event_type']}"
         user_name = payload.get("user", {}).get("name", "Undefined")

--- a/services/leecher/pyproject.toml
+++ b/services/leecher/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shotgrid-leecher"
-version = "0.2.3"
+version = "0.2.4"
 description = "Shotgrid Integration for Ayon"
 authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 
@@ -10,7 +10,7 @@ python = ">=3.9,<4.0"
 pydantic = "^1.10.2"
 nxtools = "^1.6"
 ayon-python-api = "^0.4"
-shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.3.6" }
+shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/services/leecher/pyproject.toml
+++ b/services/leecher/pyproject.toml
@@ -9,7 +9,7 @@ appdirs = "^1.4"
 python = ">=3.9,<4.0"
 pydantic = "^1.10.2"
 nxtools = "^1.6"
-ayon-python-api = "^0.4"
+ayon-python-api = "^0.5"
 shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }
 
 [tool.poetry.dev-dependencies]

--- a/services/processor/Dockerfile
+++ b/services/processor/Dockerfile
@@ -1,5 +1,5 @@
 # In order for this Dockerfile to work it needs to be built from the `services` directory
-FROM python:alpine3.18
+FROM python:3.11-alpine3.18
 ENV PYTHONUNBUFFERED=1
 
 # Install python/pip

--- a/services/processor/processor/__main__.py
+++ b/services/processor/processor/__main__.py
@@ -4,6 +4,6 @@ from .processor import ShotgridProcessor
 
 
 if __name__ == "__main__":
-    shotgird_processor = ShotgridProcessor()
-    sys.exit(shotgird_processor.start_processing())
+    shotgrid_processor = ShotgridProcessor()
+    sys.exit(shotgrid_processor.start_processing())
 

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -127,6 +127,7 @@ class ShotgridProcessor:
                     "shotgrid.proc",
                     socket.gethostname(),
                     description="Enrolling to any `shotgrid.event` Event...",
+                    max_retries=2
                 )
 
                 if not event:

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shotgrid-processor"
-version = "0.2.3"
+version = "0.2.4"
 description = "Shotgrid Integration for Ayon"
 authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 
@@ -10,7 +10,7 @@ python = ">=3.9,<4.0"
 pydantic = "^1.10.2"
 nxtools = "^1.6"
 ayon-python-api = "^0.4"
-shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.3.6" }
+shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -9,7 +9,7 @@ appdirs = "^1.4"
 python = ">=3.9,<4.0"
 pydantic = "^1.10.2"
 nxtools = "^1.6"
-ayon-python-api = "^0.4"
+ayon-python-api = "^0.5"
 shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }
 
 [tool.poetry.dev-dependencies]

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -357,14 +357,6 @@ class AyonShotgridHub:
             ayon_event (dict): A dictionary describing what
                 the change encompases, i.e. a new shot, new asset, etc.
         """
-        ay_id = ayon_event["summary"]["entityId"]
-        ay_entity = self._ay_project.get_or_query_entity_by_id(ay_id, ["folder", "task"])
-
-
-        if not ay_entity:
-            logging.error(f"Event has a non existant entity? {ay_id}")
-            return
-
         if not self._sg_project[CUST_FIELD_CODE_AUTO_SYNC]:
             logging.info(f"Ignoring event, Shotgirid field 'Ayon Auto Sync' is disabled.")
             return
@@ -383,7 +375,6 @@ class AyonShotgridHub:
                     ayon_event,
                     self._sg,
                     self._ay_project,
-                    self._sg_project,
                 )
 
             case "entity.task.renamed" | "entity.folder.renamed":
@@ -391,7 +382,6 @@ class AyonShotgridHub:
                     ayon_event,
                     self._sg,
                     self._ay_project,
-                    self._sg_project,
                 )
 
             case _:

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -137,6 +137,16 @@ def _create_new_entity(ay_entity, sg_session, sg_project, sg_parent_entity):
     """
 
     if ay_entity.entity_type == "task":
+        task_step = sg_session.find_one(
+            "Step",
+            filters=[["code", "is", ay_entity.name]],
+        )
+        if not task_step:
+            raise ValueError(
+                f"Unable to create Task {ay_entity.name} {ay_entity}\n"
+                f"    -> Shotgrid is missng Pipeline Step {ay_entity.name}"
+            )
+
         new_entity = sg_session.create(
             "Task",
             {
@@ -145,6 +155,7 @@ def _create_new_entity(ay_entity, sg_session, sg_project, sg_parent_entity):
                 CUST_FIELD_CODE_ID: ay_entity.id,
                 CUST_FIELD_CODE_SYNC: "Synced",
                 "entity": sg_parent_entity,
+                "step": task_step,
             }
         )
     else:

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -161,7 +161,7 @@ def _create_new_entity(ay_entity, sg_session, sg_project, sg_parent_entity):
     else:
         sg_parent_field = get_sg_entity_parent_field(sg_session, sg_project, ay_entity.folder_type)
 
-        if sg_parent_field == "project":
+        if sg_parent_field == "project" or sg_parent_entity["type"] == "Project":
             new_entity = sg_session.create(
                 ay_entity.folder_type,
                 {

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -145,7 +145,7 @@ def _create_new_entity(entity_hub, parent_entity, sg_entity):
     """
     if sg_entity["type"].lower() == "task":
         new_entity = entity_hub.add_new_task(
-            sg_entity["label"],
+            sg_entity["name"],
             name=sg_entity["name"],
             label=sg_entity["label"],
             entity_id=sg_entity[CUST_FIELD_CODE_ID],

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -72,6 +72,7 @@ def create_ay_entity_from_sg_event(sg_event, sg_project, sg_session, ayon_entity
         )
 
         if ay_entity:
+            logging.debug(f"SG Entity exists in AYON.")
             # Ensure Ay Entity has the correct Shotgird ID
             ay_shotgrid_id = sg_entity_dict.get(SHOTGRID_ID_ATTRIB, "")
             if ay_entity.attribs.get_attribute(SHOTGRID_ID_ATTRIB).value != str(ay_shotgrid_id):
@@ -93,6 +94,7 @@ def create_ay_entity_from_sg_event(sg_event, sg_project, sg_session, ayon_entity
         sg_entity_dict[sg_parent_field]["id"],
     )
 
+    logging.debug(f"SG Parent entity: {sg_parent_entity_dict}")
     ay_parent_entity = ayon_entity_hub.get_or_query_entity_by_id(
         sg_parent_entity_dict.get(CUST_FIELD_CODE_ID),
         ["task" if sg_parent_entity_dict.get(CUST_FIELD_CODE_ID).lower() == "task" else "folder"]
@@ -120,6 +122,7 @@ def create_ay_entity_from_sg_event(sg_event, sg_project, sg_session, ayon_entity
             parent_id=ay_parent_entity.id
         )
 
+    logging.debug(f"Created new AYON entity: {ay_entity}")
     ay_entity.attribs.set(
         SHOTGRID_ID_ATTRIB,
         sg_entity_dict.get(SHOTGRID_ID_ATTRIB, "")

--- a/services/shotgrid_common/constants.py
+++ b/services/shotgrid_common/constants.py
@@ -126,6 +126,7 @@ SG_COMMON_ENTITY_FIELDS = [
     "sg_asset_type",
     "content",
     "entity",
+    "step",
     CUST_FIELD_CODE_ID,
     CUST_FIELD_CODE_SYNC,
 ]

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -30,7 +30,7 @@ def _sg_to_ay_dict(sg_entity: dict, project_code_field=None) -> dict:
         project_code_field = "code"
 
     if sg_entity["type"] == "Task":
-        name = slugify_string(sg_entity["content"])
+        name = sg_entity["step"]["name"]
         label = sg_entity["content"]
     elif sg_entity["type"] == "Project":
         name = slugify_string(sg_entity[project_code_field])
@@ -113,7 +113,7 @@ def create_sg_entities_in_ay(
     sg_session: shotgun_api3.Shotgun,
     shotgrid_project: dict
 ):
-    """Ensure Ayon has all the Shotgrid Taks and Folder types.
+    """Ensure Ayon has all the Shotgrid Tasks and Folder types.
 
     Args:
         project_entity (ProjectEntity): The ProjectEntity for a given project.
@@ -154,6 +154,7 @@ def create_sg_entities_in_ay(
         task['name']: task
         for task in new_tasks
     }.values())
+
     project_entity.folder_types = new_entities
     project_entity.task_types = new_tasks
 
@@ -297,7 +298,6 @@ def get_sg_entities(
             filters=[["project", "is", sg_project]],
             fields=common_fields,
         )
-
         if sg_entities:
             for entity in sg_entities:
                 parent_id = sg_project["id"]
@@ -566,7 +566,7 @@ def get_sg_statuses(sg_session: shotgun_api3.Shotgun) -> dict:
         (status["code"], status["name"])
         for status in sg_session.find("Status", [], fields=["name", "code"])
     ]
-
+    logging.debug(f"Shotgrid Statuses: {sg_statuses}")
     return sg_statuses
 
 
@@ -604,5 +604,7 @@ def get_sg_tasks_entities(
     for step in pipeline_steps:
         sg_tasks.append((step["code"], step["short_name"].lower()))
 
-    return list(set(sg_tasks))
+    sg_tasks = list(set(sg_tasks))
+    logging.debug(f"Shotgrid Tasks: {sg_tasks}")
+    return sg_tasks
 

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -529,6 +529,10 @@ def get_sg_project_enabled_entities(
         if sg_entity_type == "Project":
             continue
 
+        if sg_entity_type == "Version":
+            project_entities.append((sg_entity_type, "entity"))
+            continue
+
         is_entity_enabled = sg_project_schema.get(
             sg_entity_type, {}
         ).get("visible", {}).get("value", False)

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -30,6 +30,11 @@ def _sg_to_ay_dict(sg_entity: dict, project_code_field=None) -> dict:
         project_code_field = "code"
 
     if sg_entity["type"] == "Task":
+        if not sg_entity["step"]:
+            raise ValueError(
+                f"Task {sg_entity} has not Pipeline Step assigned."
+            )
+
         name = sg_entity["step"]["name"]
         label = sg_entity["content"]
     elif sg_entity["type"] == "Project":

--- a/services/transmitter/Dockerfile
+++ b/services/transmitter/Dockerfile
@@ -1,5 +1,5 @@
 # In order for this Dockerfile to work it needs to be built from the `services` directory
-FROM python:alpine3.18
+FROM python:3.11-alpine3.18
 ENV PYTHONUNBUFFERED=1
 
 # Install python/pip

--- a/services/transmitter/pyproject.toml
+++ b/services/transmitter/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shotgrid-transmitter"
-version = "0.2.3"
+version = "0.2.4"
 description = "Shotgrid Integration for Ayon"
 authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 
@@ -10,7 +10,7 @@ python = ">=3.9,<4.0"
 pydantic = "^1.10.2"
 nxtools = "^1.6"
 ayon-python-api = "^0.4"
-shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.3.6" }
+shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/services/transmitter/pyproject.toml
+++ b/services/transmitter/pyproject.toml
@@ -9,7 +9,7 @@ appdirs = "^1.4"
 python = ">=3.9,<4.0"
 pydantic = "^1.10.2"
 nxtools = "^1.6"
-ayon-python-api = "^0.4"
+ayon-python-api = "^0.5"
 shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }
 
 [tool.poetry.dev-dependencies]

--- a/services/transmitter/transmitter/__main__.py
+++ b/services/transmitter/transmitter/__main__.py
@@ -4,6 +4,6 @@ from .transmitter import ShotgridTransmitter
 
 
 if __name__ == "__main__":
-    shotgird_transmitter = ShotgridTransmitter()
-    sys.exit(shotgird_transmitter.start_processing())
+    shotgrid_transmitter = ShotgridTransmitter()
+    sys.exit(shotgrid_transmitter.start_processing())
 

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -123,7 +123,6 @@ class ShotgridTransmitter:
                     self.sg_script_name
                 )
 
-                logging.warning(source_event)
                 hub.react_to_ayon_event(source_event)
 
                 logging.info("Event has been processed... setting to finished!")

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -89,7 +89,8 @@ class ShotgridTransmitter:
                             },
                         ],
                         "operator": "and",
-                    }
+                    },
+                    max_retries=2
                 )
 
                 if not event:

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring addon version."""
-__version__ = "0.2.4"
+__version__ = "0.2.5"


### PR DESCRIPTION
Changes:
*  `client` Bump Shotgrid API version to v3.4.0
*  `ayon_shotgrid_hub` Better logging when creating from SG event
* `services.utils` Version's parent field is always entity
* `client` Fix duplicated root for local files On Windows, when creating a `PublishedFile` the server was prepending the project root to the filepath which it already had it, this commit will read the first Local Storage defined in Shotgrid and attempt to get a partial path of the file, which is then used to create the `PublishedFile` and avoids the double root.
*  `service` Update the Shotgrid API to v3.4.0
* `Makefile` fix removing existing docker image The previous command to find container images wasn't really working, with this change we now ensure we are deleting the local image if there's any found with the same tag.
* `services` Pin base image to `python:3.11-alpine3.18` Python Docker images maintainers decided to upgrade to Python 3.12 for the Alpine 3.18 images, even though the default Python in Alpine is 3.11.
* `services` Bump `ayon-python-api` verion to `^0.5`
* `services` Fix variable typo in `__main__` I mistyped "shotgird" in the initial implementation, this commit fixes the three instances of the typo.
* `services` - Add `max_retries` to `enroll_event_job` The server won't allow to enroll with a null value for `max_retries` when enrolling jobs, we now specify it, and set it to two, this could potentially be added to the Shotgrid settings.
* `shotgrid_common` Fix Tasks creation form SG When we made the change to use Pipeline Steps for the tasks creation, we didn't change the `utils` to get the correct name of the Task (the step name), which then it made it fail when attempting to create taks, since we were still using the SG task name, which didn't match any task in AYON.
* `services` Improve logging for `transmitter` and `leecher`
* `ayon_shotgrid_hub` Improve Sync for "parentless" entities Fixed when we create entities in Shotgrid which parents should be the Project, instead of assigning the project as a Sequence for a Shot for example.
