### PR TITLE
Version 0.2.6 Fixes

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -85,8 +85,8 @@ class ShotgridAddon(BaseServerAddon):
             {
                 "type": "string",
                 "title": "Shotgrid ID",
-                "description": "The ID in the Shotgrid Instance.",
-                "inherit": "False"
+                "description": "The Shotgrid ID of this entity.",
+                "inherit": False
             }
         )
 
@@ -98,8 +98,8 @@ class ShotgridAddon(BaseServerAddon):
             {
                 "type": "string",
                 "title": "Shotgrid Type",
-                "decription": "The Type of the Shotgrid entity.",
-                "inherit": "False"
+                "description": "The Shotgrid Type of this entity.",
+                "inherit": False
             }
         )
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,18 +1,10 @@
-import json
-import socket
 from typing import Any, Type
 
 from ayon_server.addons import BaseServerAddon
-from ayon_server.api.dependencies import dep_current_user, dep_project_name
-from ayon_server.entities import UserEntity
-from ayon_server.events import dispatch_event
 from ayon_server.lib.postgres import Postgres
 from .settings import ShotgridSettings, DEFAULT_VALUES
 from .version import __version__
 
-from fastapi import Depends
-import requests
-from starlette.requests import Request
 from nxtools import logging
 
 
@@ -33,206 +25,6 @@ class ShotgridAddon(BaseServerAddon):
         "ShotgridProcessor": {"image": f"ynput/ayon-shotgrid-processor:{__version__}"},
         "ShotgridTransmitter": {"image": f"ynput/ayon-shotgrid-transmitter:{__version__}"},
     }
-
-    def initialize(self):
-        logging.info("Initializing Shotgrid Addon.")
-
-        self.add_endpoint(
-            "create-project",
-            self._create_project,
-            method="POST",
-            name="create-shotgrid-project",
-            description="Create project in Ayon, with the given name.",
-        )
-        logging.info("Added Create Project Endpoint.")
-
-        self.add_endpoint(
-            "sync-from-shotgrid/{project_name}",
-            self._sync_from_shotgrid,
-            method="GET",
-            name="sync-from-shotgrid",
-            description="Trigger Shotgrid -> Ayon Sync of entities.",
-        )
-        logging.info("Added Sync from Shotgrid Project Endpoint.")
-
-        self.add_endpoint(
-            "get-importable-projects",
-            self._get_importable_projects,
-            method="GET",
-            name="get-importable-projects",
-            description="Return a list of Shotgrid projects ready to be imported into Ayon.",
-        )
-        logging.info("Added Get Syncable Projects Endpoint.")
-
-    async def _dispatch_shotgrid_event(
-        self,
-        action,
-        user_name,
-        project_name,
-        description=None
-    ):
-        addon_settings = await self.get_studio_settings()
-
-        event_id = await dispatch_event(
-            "shotgrid.event",
-            sender=socket.gethostname(),
-            project=project_name,
-            user=user_name,
-            description=description,
-            summary=None,
-            payload={
-                "action": action,
-                "user_name": user_name,
-                "project_name": project_name,
-                "project_code_field": addon_settings.shotgrid_project_code_field,
-            },
-        )
-        logging.info(f"Dispatched event {event_id}")
-        return event_id
-
-    async def _sync_from_shotgrid(
-        self,
-        user: UserEntity = Depends(dep_current_user),
-        project_name: str = Depends(dep_project_name),
-    ):
-        addon_settings = await self.get_studio_settings()
-
-        await self._dispatch_shotgrid_event(
-            "sync-from-shotgrid",
-            user.name,
-            project_name,
-            description=f"Sync project '{project_name}' from Shotgrid."
-        )
-
-    async def _create_project(
-        self,
-        request: Request,
-        user: UserEntity = Depends(dep_current_user)
-    ):
-        request_body = await request.body()
-
-        if not request_body:
-            logging.error(f"Request has no body: {request_body}")
-            return
-        else:
-            request_body = json.loads(request_body)
-
-        addon_settings = await self.get_studio_settings()
-        project_name = request_body.get("project_name")
-        project_code = request_body.get("project_code")
-
-        logging.info("Project name is: ", project_name)
-        description = f"Create {project_name} from Shotgrid."
-
-        if project_name and project_code:
-            event_id = await dispatch_event(
-                "shotgrid.event",
-                sender=socket.gethostname(),
-                project=project_name,
-                user=user.name,
-                description=description,
-                summary=None,
-                payload={
-                    "action": "create-project",
-                    "user_name": user.name,
-                    "project_name": project_name,
-                    "project_code": project_code,
-                    "project_code_field": addon_settings.shotgrid_project_code_field,
-                    "description": description,
-                },
-            )
-            logging.info(f"Dispatched event {event_id}")
-
-    async def _get_importable_projects(self):
-        """ Query Shotgrid for existing non-template Projects.
-
-        It uses the Rest APi to avoid importing the Shotgrid API.
-        """
-        logging.info("Trying to fetch projects from Shotgrid.")
-        addon_settings = await self.get_studio_settings()
-
-        if not addon_settings:
-            logging.error(f"Unable to get Studio Settings: {self.name} addon.")
-            return
-        elif not all((
-            addon_settings.shotgrid_server,
-            addon_settings.shotgrid_script_name,
-            addon_settings.shotgrid_api_key,
-            addon_settings.shotgrid_project_code_field
-        )):
-            logging.error("Missing data in the addon settings.")
-            return
-
-        shotgrid_url = addon_settings.shotgrid_server
-        if shotgrid_url.endswith("/"):
-            shotgrid_url = shotgrid_url.rstrip("/").strip()
-
-
-        shotgrid_credentials_token = requests.post(
-            f"{shotgrid_url}/api/v1/auth/access_token",
-            data={
-                "client_id": f"{addon_settings.shotgrid_script_name}",
-                "client_secret": f"{addon_settings.shotgrid_api_key}",
-                "grant_type": "client_credentials"
-            }
-        )
-        shotgrid_token = shotgrid_credentials_token.json().get('access_token')
-
-        if not shotgrid_token:
-            logging.error(f"Unable to Acquire Shotgrid REST API token. {shotgrid_credentials_token.json()}")
-            return
-
-        logging.info("Querying the Shotgrid REST API token.")
-        request_headers = {
-            "Authorization": f"Bearer {shotgrid_token}",
-            "Accept": "application/vnd+shotgun.api3_array+json"
-        }
-
-        shotgrid_projects = requests.get(
-            f"{shotgrid_url}/api/v1/entity/projects/",
-            headers=request_headers
-        )
-
-        sg_projects = []
-
-        if shotgrid_projects.json().get("data"):
-            logging.info("Shotgrid REST API returned some data, processing it.")
-            for project in shotgrid_projects.json().get("data"):
-                sg_project = requests.get(
-                    f"{shotgrid_url}/api/v1/entity/projects/{project['id']}",
-                    data=json.dumps({
-                        "fields": [
-                            "name",
-                            addon_settings.shotgrid_project_code_field,
-                            "sg_ayon_sync_status",
-                        ],
-                        "filters": [
-                            [addon_settings.shotgrid_project_code_field, "is_not", None],
-                            ["name", "not_contains", " "]
-                        ]
-                    }),
-                    headers=request_headers
-                )
-                if not sg_project.json()["data"]:
-                    continue
-
-                sg_project = sg_project.json()["data"]
-
-                if sg_project["attributes"].get("is_template"):
-                    continue
-
-                sg_projects.append({
-                    "projectName": sg_project["attributes"].get("name"),
-                    "projectCode": sg_project["attributes"].get(
-                        addon_settings.shotgrid_project_code_field
-                    ),
-                    "shotgridId": sg_project["id"],
-                    "ayonId": sg_project["attributes"].get("sg_ayon_id"),
-                    "ayonAutoSync": sg_project["attributes"].get("sg_ayon_auto_sync"),
-                })
-        logging.info("Finished processing Shotgrid data.")
-        logging.debug(f"Processed the following projects {sg_projects}.")
-        return sg_projects
 
     async def get_default_settings(self):
         logging.info(f"Loading default Settings for {self.name} addon.")
@@ -293,7 +85,8 @@ class ShotgridAddon(BaseServerAddon):
             {
                 "type": "string",
                 "title": "Shotgrid ID",
-                "description": "The ID in the Shotgrid Instance."
+                "description": "The ID in the Shotgrid Instance.",
+                "inherit": "False"
             }
         )
 
@@ -305,7 +98,8 @@ class ShotgridAddon(BaseServerAddon):
             {
                 "type": "string",
                 "title": "Shotgrid Type",
-                "decription": "The Type of the Shotgrid entity."
+                "decription": "The Type of the Shotgrid entity.",
+                "inherit": "False"
             }
         )
 

--- a/server/frontend/dist/shotgrid-addon.js
+++ b/server/frontend/dist/shotgrid-addon.js
@@ -54,6 +54,7 @@ const populateTable = async () => {
       }
     })
     if (!already_exists) {
+      sg_project.ayonId = null
       allProjects.push(sg_project)
     }
   })

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -137,21 +137,29 @@ def _create_new_entity(ay_entity, sg_session, sg_project, sg_parent_entity):
     """
 
     if ay_entity.entity_type == "task":
+
+        step_query_filters = [["code", "is", ay_entity.task_type]]
+
+        if sg_parent_entity["type"] in ["Asset", "Shot"]:
+            step_query_filters.append(
+                ["entity_type", "is", sg_parent_entity["type"]]
+            )
+
         task_step = sg_session.find_one(
             "Step",
-            filters=[["code", "is", ay_entity.name]],
+            filters=step_query_filters,
         )
         if not task_step:
             raise ValueError(
-                f"Unable to create Task {ay_entity.name} {ay_entity}\n"
-                f"    -> Shotgrid is missng Pipeline Step {ay_entity.name}"
+                f"Unable to create Task {ay_entity.task_type} {ay_entity}\n"
+                f"    -> Shotgrid is missng Pipeline Step {ay_entity.task_type}"
             )
 
         new_entity = sg_session.create(
             "Task",
             {
                 "project": sg_project,
-                "content": ay_entity.name,
+                "content": ay_entity.label,
                 CUST_FIELD_CODE_ID: ay_entity.id,
                 CUST_FIELD_CODE_SYNC: "Synced",
                 "entity": sg_parent_entity,

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -146,7 +146,7 @@ def _create_new_entity(entity_hub, parent_entity, sg_entity):
     if sg_entity["type"].lower() == "task":
         new_entity = entity_hub.add_new_task(
             sg_entity["name"],
-            name=sg_entity["name"],
+            name=sg_entity["label"],
             label=sg_entity["label"],
             entity_id=sg_entity[CUST_FIELD_CODE_ID],
             parent_id=parent_entity.id


### PR DESCRIPTION
* `server` Remove custom endpoints In an initial iteration of the ADddon we were using custom endpoints, but since we now rely solely in the event system these are no longer needed, they could be re-implemented later on if deemed necessary.
* `server` Fix Shotgrid Attributes Make sure the Shotgrid attributes have "inherit" set as false and fix the description for the `shotgridType`
* `ayon_shotgrid_hub` Use SG Task name for AYON In a previous commit we changed the logic to use the Pipeline Steps as Task types in AYON, but we still want to create tasks of the same type, but with different names.
* `frontend` Fix showing projects existing in AYON When parsing the different projects from SG and AYON to populate the table we were appending SG projects, which might contain the AYON ID, and disregarding if they infact were in AYON or not, with this commit we honour the AYOn query and we modify the SG project object acordingly.