### PR TITLE
Bugfixes for 0.2.6

### DIFF
--- a/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_publish.py
+++ b/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_publish.py
@@ -73,6 +73,7 @@ class IntegrateShotgridPublish(pyblish.api.InstancePlugin):
                     _, file_partial_path = local_path.split(
                         sg_local_store["windows_path"]
                     )
+                    file_partial_path = file_partial_path.replace("\\", "/")
                 elif platform.system() == "Linux":
                     _, file_partial_path = local_path.split(
                         sg_local_store["linux_path"]
@@ -81,6 +82,8 @@ class IntegrateShotgridPublish(pyblish.api.InstancePlugin):
                     _, file_partial_path = local_path.split(
                         sg_local_store["mac_path"]
                     )
+
+                file_partial_path = file_partial_path.lstrip("/")
             except ValueError:
                 raise KnownPublishError(
                     f"Filepath {local_path} doesn't match the "


### PR DESCRIPTION
* `ayon_shotgrid_hub` Correctly handle Asset Categories With this changes we now have a new Folder type in ayon "AssetCategory" to handle those incoming from the Shotgrid. A new function `get_asset_category` has been added in `utils` to handle the query of these in AYON.
* `client` Fix `PublishedFile` relative path Shotgrid doesn't like it if the `relative_path` is not forward slashes and if there's a leading forward slash.