### PR TITLE
Pass custom project code field to other functions that use it

### DIFF
--- a/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_version.py
+++ b/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_version.py
@@ -60,7 +60,7 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
                         local_path, sg_version.get("id")
                     )
                 )
-                self.sg_session.upload(
+                sg_session.upload(
                     "Version",
                     sg_version.get("id"),
                     local_path,

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -162,6 +162,7 @@ class ShotgridProcessor:
                             self.sg_url,
                             self.sg_script_name,
                             self.sg_api_key,
+                            project_field_code=self.sg_project_code_field,
                             **payload,
                         )
 

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -292,7 +292,8 @@ class AyonShotgridHub:
                 match_shotgrid_hierarchy_in_ayon(
                     self._ay_project,
                     self._sg_project,
-                    self._sg
+                    self._sg,
+                    self.sg_project_code_field,
                 )
 
             case _:

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -12,7 +12,9 @@ from utils import get_sg_entities, get_asset_category
 from nxtools import logging, log_traceback
 
 
-def match_shotgrid_hierarchy_in_ayon(entity_hub, sg_project, sg_session):
+def match_shotgrid_hierarchy_in_ayon(
+    entity_hub, sg_project, sg_session, project_field_code
+):
     """Replicate a Shotgrid project into AYON.
 
     This function creates a "deck" which we keep increasing while traversing
@@ -24,11 +26,13 @@ def match_shotgrid_hierarchy_in_ayon(entity_hub, sg_project, sg_session):
         entity_hub (ayon_api.entity_hub.EntityHub): The AYON EntityHub.
         sg_project (dict): The Shotgrid project.
         sg_project (shotgun_api3.Shotgun): The Shotgrid session.
+        project_code_field (str): The Shotgrid project code field.
     """
 
     sg_entities_by_id, sg_entities_by_parent_id = get_sg_entities(
         sg_session,
         sg_project,
+        project_code_field=project_field_code
     )
 
     sg_entities_deck = collections.deque()


### PR DESCRIPTION
I was still getting errors due to our Shotgrid using `sg_code` instead of `code` for the field name to reference the code:
```
023-11-28 15:20:50 ERROR      API create() Project.code doesn't exist:
{"field_name"=>"code", "value"=>"dev_000"}

    Traceback (most recent call last):
      File "/service/processor/processor.py", line 161, in start_processing
        handler.process_event(
      File "/service/processor/handlers/sync_projects.py", line 38, in process_event
        hub.create_project()
      File "/service/ayon_shotgrid_hub/__init__.py", line 214, in create_project
        self._sg_project = self._sg.create(
                           ^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.11/site-packages/shotgun_api3/shotgun.py", line 1392, in create
        record = self._call_rpc("create", params, first=True)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.11/site-packages/shotgun_api3/shotgun.py", line 3423, in _call_rpc
        self._response_errors(response)
```

This also fixes the issue https://github.com/ynput/ayon-shotgrid/issues/54 raised by @matteoveglia:
```
Traceback (most recent call last):
  File "C:\Users\MatteoVeglia\AppData\Local\Ynput\AYON\dependency_packages\ayon_2310271602_windows.zip\dependencies\pyblish\plugin.py", line 527, in __explicit_process
    runner(*args)
  File "C:\Users\MatteoVeglia\AppData\Local\Ynput\AYON\addons\shotgrid_0.2.7\ayon_shotgrid\plugins\publish\integrate_shotgrid_version.py", line 63, in process
    self.sg_session.upload(
AttributeError: 'IntegrateShotgridVersion' object has no attribute 'sg_session'
```

