### PR TITLE
fix: Removed incorect usage of event.summary field (must be a dict)

### DIFF
--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -172,12 +172,11 @@ class ShotgridProcessor:
                             event["id"],
                             status="failed",
                             description=f"An error ocurred while processing the Event: {e}",
-                            summary="Feiled procesing the event Handler..."
                         )
                         ayon_api.update_event(
                             source_event["id"],
                             status="failed",
-                            summary=f"The service `processor` was unable to process this event. Check the `shotgrid.proc` <{event['id']}> event for more info."
+                            description=f"The service `processor` was unable to process this event. Check the `shotgrid.proc` <{event['id']}> event for more info."
                         )
 
                 logging.info("Event has been processed... setting to finished!")


### PR DESCRIPTION
Summary field must be a dict. Human readable description of an event should go to `description`. Passing strings to summary causes 419 errors.