### PR TITLE
Fix bug where custom project code field wasn't being used on sync from Ayon to SG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,18 @@ Temporary Items
 # IDEA
 ######
 .idea/
+
+# Add symlinked files to ignore
+client/ayon_shotgrid/version.py
+services/leecher/__init__.py
+services/leecher/ayon_shotgrid_hub
+services/leecher/constants.py
+services/leecher/utils.py
+services/processor/__init__.py
+services/processor/ayon_shotgrid_hub
+services/processor/constants.py
+services/processor/utils.py
+services/transmitter/__init__.py
+services/transmitter/ayon_shotgrid_hub
+services/transmitter/constants.py
+services/transmitter/utils.py

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -162,7 +162,6 @@ class ShotgridProcessor:
                             self.sg_url,
                             self.sg_script_name,
                             self.sg_api_key,
-                            project_code_field=self.sg_project_code_field,
                             **payload,
                         )
 

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -171,7 +171,7 @@ class AyonShotgridHub:
         try:
             self._ay_project = EntityHub(project_name)
             self._ay_project.project_entity
-            logging.info(f"Project {project_name} <{self._ay_project.project_entity.id}> already exist in AYON.")
+            logging.info(f"Project {project_name} <{self._ay_project.project_entity.id}> already exists in AYON.")
         except Exception as err:
             logging.warning(f"Project {project_name} does not exist in AYON.")
             log_traceback(err)
@@ -186,7 +186,7 @@ class AyonShotgridHub:
                     CUST_FIELD_CODE_AUTO_SYNC
                 ]
             )
-            logging.info(f"Project {project_name} ({self._sg_project[self.sg_project_code_field]}) <{self._sg_project['id']}> already exist in Shotgrid.")
+            logging.info(f"Project {project_name} ({self._sg_project[self.sg_project_code_field]}) <{self._sg_project['id']}> already exists in Shotgrid.")
         except Exception as e:
             logging.warning(f"Project {project_name} does not exist in Shotgrid. ")
             log_traceback(e)

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -214,12 +214,12 @@ def update_ayon_entity_from_sg_event(sg_event, sg_session, ayon_entity_hub, proj
     )
 
     if not ay_entity:
-        logging.error("Unable to update an non existant entity.")
-        raise ValueError("Unable to update an non existant entity.")
+        logging.error("Unable to update a non existing entity.")
+        raise ValueError("Unable to update a non existing entity.")
 
     if int(ay_entity.attribs.get_attribute(SHOTGRID_ID_ATTRIB).value) != int(sg_entity_dict.get(SHOTGRID_ID_ATTRIB)):
-        logging.error("Missmatching Shotgrid IDs, aborting...")
-        raise ValueError("Missmatching Shotgrid IDs, aborting...")
+        logging.error("Mismatching Shotgrid IDs, aborting...")
+        raise ValueError("Mismatching Shotgrid IDs, aborting...")
 
     if sg_event["attribute_name"] in ["code", "name"]:
         if ay_entity.name != sg_entity_dict["name"]:
@@ -273,12 +273,12 @@ def remove_ayon_entity_from_sg_event(sg_event, sg_session, ayon_entity_hub, proj
     )
 
     if not ay_entity:
-        logging.error("Unable to update an non existant entity.")
-        raise ValueError("Unable to update an non existant entity.")
+        logging.error("Unable to update a non existing entity.")
+        raise ValueError("Unable to update a non existing entity.")
 
     if sg_entity_dict.get(CUST_FIELD_CODE_ID) != ay_entity.id:
-        logging.error("Missmatching Shotgrid IDs, aborting...")
-        raise ValueError("Missmatching Shotgrid IDs, aborting...")
+        logging.error("Mismatching Shotgrid IDs, aborting...")
+        raise ValueError("Mismatching Shotgrid IDs, aborting...")
 
     if not ay_entity.immutable_for_hierarchy:
         logging.info(f"Deleting AYON entity: {ay_entity}")

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -415,7 +415,10 @@ def get_sg_entity_as_ay_dict(
     query_fields = list(SG_COMMON_ENTITY_FIELDS)
     if extra_fields and isinstance(extra_fields, list):
         query_fields.extend(extra_fields)
-
+    
+    if project_code_field not in query_fields:
+        query_fields.append(project_code_field)
+        
     sg_entity = sg_session.find_one(
         sg_type,
         filters=[["id", "is", sg_id]],

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -43,8 +43,6 @@ def _sg_to_ay_dict(sg_entity: dict, project_code_field=None) -> dict:
 
         if not label and not task_type:
             raise ValueError(f"Unable to parse Task {sg_entity}")
-        else:
-            label = sg_entity["step"]["name"]
 
         name = slugify_string(label)
 


### PR DESCRIPTION
The custom project code field was missing on this call:
```
    # Append the project's direct children.
    for ay_project_child in entity_hub._entities_by_parent_id[entity_hub.project_name]:
        ay_entities_deck.append((
            get_sg_entity_as_ay_dict(sg_session, "Project", sg_project["id"], project_code_field),
            ay_project_child
        ))
```

Although perhaps better than querying the `sg_project` again the best would be to append the existing `sg_project` variable that already exists on the function and contains the project code field, something like:

```
    # Append the project's direct children.
    for ay_project_child in entity_hub._entities_by_parent_id[entity_hub.project_name]:
        ay_entities_deck.append((
           _sg_to_ay_dict(sg_project, project_code_field)
            ay_project_child
        ))
```

@Minkiu thoughts?