### PR TITLE
Release 0.3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,18 @@ Temporary Items
 # IDEA
 ######
 .idea/
+
+# Add symlinked files to ignore
+client/ayon_shotgrid/version.py
+services/leecher/__init__.py
+services/leecher/ayon_shotgrid_hub
+services/leecher/constants.py
+services/leecher/utils.py
+services/processor/__init__.py
+services/processor/ayon_shotgrid_hub
+services/processor/constants.py
+services/processor/utils.py
+services/transmitter/__init__.py
+services/transmitter/ayon_shotgrid_hub
+services/transmitter/constants.py
+services/transmitter/utils.py

--- a/client/ayon_shotgrid/addon.py
+++ b/client/ayon_shotgrid/addon.py
@@ -20,6 +20,8 @@ class ShotgridAddon(OpenPypeModule, IPluginPaths):
         sg_secret = ayon_api.get_secret(module_settings["shotgrid_api_secret"])
         self._shotgrid_script_name = sg_secret.get("name")
         self._shotgrid_api_key = sg_secret.get("value")
+        self._enable_local_storage = module_settings.get("enable_shotgrid_local_storage")
+        self._local_storage_key = module_settings.get("local_storage_key")
 
     def get_sg_url(self):
         return self._shotgrid_server_url if self._shotgrid_server_url else None
@@ -37,6 +39,12 @@ class ShotgridAddon(OpenPypeModule, IPluginPaths):
             ]
         }
 
+    def is_local_storage_enabled(self):
+        return self._enable_local_storage if self._enable_local_storage else False
+    
+    def get_local_storage_key(self):
+        return self._local_storage_key if self._local_storage_key else None
+    
     def create_shotgrid_session(self):
         from .lib import credentials
 

--- a/client/ayon_shotgrid/plugins/publish/collect_shotgrid_session.py
+++ b/client/ayon_shotgrid/plugins/publish/collect_shotgrid_session.py
@@ -32,11 +32,9 @@ class CollectShotgridSession(pyblish.api.ContextPlugin):
         except Exception as e:
             self.log.error("Failed to connect to Shotgrid.", exc_info=True)
             raise KnownPublishError(
-                "Could not connect to Shotgrid {0} with user {1}.".format(
-                shotgrid_url,
-                user_login
-                )
-            )
+                f"Could not connect to Shotgrid {shotgrid_url} "
+                f"with user {user_login}."
+            ) from e
 
         if sg_session is None:
             raise KnownPublishError(
@@ -49,3 +47,11 @@ class CollectShotgridSession(pyblish.api.ContextPlugin):
         context.data["shotgridSession"] = sg_session
         context.data["shotgridUser"] = user_login
 
+        local_storage_enabled = shotgrid_module.is_local_storage_enabled()
+        context.data["shotgridLocalStorageEnabled"] = local_storage_enabled
+        self.log.info(f"Shotgrid local storage enabled: {local_storage_enabled}")
+        if local_storage_enabled:
+            local_storage_key = shotgrid_module.get_local_storage_key()
+            self.log.info(f"Using local storage entry {local_storage_key}")
+            context.data["shotgridLocalStorageKey"] = local_storage_key
+        

--- a/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_version.py
+++ b/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_version.py
@@ -61,7 +61,10 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
 
         # If there's no data to set/update, skip creation of SG version
         if not data_to_update:
-            self.log.info("No data to integrate to SG, skipping version creation.")
+            self.log.info(
+                "No data to integrate to SG for subset '%s', skipping version creation.",
+                instance.data["subset"]
+            )
             return
         
         sg_session = context.data["shotgridSession"]

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -47,7 +47,18 @@ class ShotgridSettings(BaseSettingsModel):
         default="code",
         title="Shotgrid Project Code field name",
         description="In order to create AYON projects, we need a Project Code, you can specify here which field in the Shotgrid Project entitiy represents it.",
-        excample="sg_code"
+        example="sg_code"
+    )
+    enable_shotgrid_local_storage: bool = Field(
+        default=True,
+        title="Enable Shotgrid Local Storage.",
+        description="Whether to try make use of local storage defined in Shotgrid ('Site Preferences -> File Management -> Local Storage') or not."
+    )
+    shotgrid_local_storage_key: str = Field(
+        default="primary",
+        title="Shotgrid Local Storage entry name",
+        description="Name of the 'code' to select which one of the multiple possible local storages entries to use.",
+        example="ayon_storage"
     )
     service_settings: ShotgridServiceSettings = Field(
         default_factory=ShotgridServiceSettings,

--- a/services/leecher/pyproject.toml
+++ b/services/leecher/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shotgrid-leecher"
-version = "0.3.1"
+version = "0.3.2"
 description = "Shotgrid Integration for Ayon"
 authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -162,7 +162,6 @@ class ShotgridProcessor:
                             self.sg_url,
                             self.sg_script_name,
                             self.sg_api_key,
-                            project_code_field=self.sg_project_code_field,
                             **payload,
                         )
 

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shotgrid-processor"
-version = "0.3.1"
+version = "0.3.2"
 description = "Shotgrid Integration for Ayon"
 authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -171,7 +171,7 @@ class AyonShotgridHub:
         try:
             self._ay_project = EntityHub(project_name)
             self._ay_project.project_entity
-            logging.info(f"Project {project_name} <{self._ay_project.project_entity.id}> already exist in AYON.")
+            logging.info(f"Project {project_name} <{self._ay_project.project_entity.id}> already exists in AYON.")
         except Exception as err:
             logging.warning(f"Project {project_name} does not exist in AYON.")
             log_traceback(err)
@@ -186,7 +186,7 @@ class AyonShotgridHub:
                     CUST_FIELD_CODE_AUTO_SYNC
                 ]
             )
-            logging.info(f"Project {project_name} ({self._sg_project[self.sg_project_code_field]}) <{self._sg_project['id']}> already exist in Shotgrid.")
+            logging.info(f"Project {project_name} ({self._sg_project[self.sg_project_code_field]}) <{self._sg_project['id']}> already exists in Shotgrid.")
         except Exception as e:
             logging.warning(f"Project {project_name} does not exist in Shotgrid. ")
             log_traceback(e)

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -214,12 +214,12 @@ def update_ayon_entity_from_sg_event(sg_event, sg_session, ayon_entity_hub, proj
     )
 
     if not ay_entity:
-        logging.error("Unable to update an non existant entity.")
-        raise ValueError("Unable to update an non existant entity.")
+        logging.error("Unable to update a non existing entity.")
+        raise ValueError("Unable to update a non existing entity.")
 
     if int(ay_entity.attribs.get_attribute(SHOTGRID_ID_ATTRIB).value) != int(sg_entity_dict.get(SHOTGRID_ID_ATTRIB)):
-        logging.error("Missmatching Shotgrid IDs, aborting...")
-        raise ValueError("Missmatching Shotgrid IDs, aborting...")
+        logging.error("Mismatching Shotgrid IDs, aborting...")
+        raise ValueError("Mismatching Shotgrid IDs, aborting...")
 
     if sg_event["attribute_name"] in ["code", "name"]:
         if ay_entity.name != sg_entity_dict["name"]:
@@ -273,12 +273,12 @@ def remove_ayon_entity_from_sg_event(sg_event, sg_session, ayon_entity_hub, proj
     )
 
     if not ay_entity:
-        logging.error("Unable to update an non existant entity.")
-        raise ValueError("Unable to update an non existant entity.")
+        logging.error("Unable to update a non existing entity.")
+        raise ValueError("Unable to update a non existing entity.")
 
     if sg_entity_dict.get(CUST_FIELD_CODE_ID) != ay_entity.id:
-        logging.error("Missmatching Shotgrid IDs, aborting...")
-        raise ValueError("Missmatching Shotgrid IDs, aborting...")
+        logging.error("Mismatching Shotgrid IDs, aborting...")
+        raise ValueError("Mismatching Shotgrid IDs, aborting...")
 
     if not ay_entity.immutable_for_hierarchy:
         logging.info(f"Deleting AYON entity: {ay_entity}")

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -415,7 +415,10 @@ def get_sg_entity_as_ay_dict(
     query_fields = list(SG_COMMON_ENTITY_FIELDS)
     if extra_fields and isinstance(extra_fields, list):
         query_fields.extend(extra_fields)
-
+    
+    if project_code_field not in query_fields:
+        query_fields.append(project_code_field)
+        
     sg_entity = sg_session.find_one(
         sg_type,
         filters=[["id", "is", sg_id]],

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -43,8 +43,6 @@ def _sg_to_ay_dict(sg_entity: dict, project_code_field=None) -> dict:
 
         if not label and not task_type:
             raise ValueError(f"Unable to parse Task {sg_entity}")
-        else:
-            label = sg_entity["step"]["name"]
 
         name = slugify_string(label)
 

--- a/services/transmitter/pyproject.toml
+++ b/services/transmitter/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shotgrid-transmitter"
-version = "0.3.1"
+version = "0.3.2"
 description = "Shotgrid Integration for Ayon"
 authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring addon version."""
-__version__ = "0.3.1"
+__version__ = "0.3.2"


### PR DESCRIPTION
Merging for new release, this one includes mostly bugfixes either introduced in `0.3.1` or improvements to the `client` side.
* `services` Fix bug where custom project code field wasn't being used to query entity
* Add symlinked files to gitignore
* `services` Fix bug that was overriding label with step name and fix some typos on logging
* `client` Expose whether to enable SG local storage and make use of it
* `general` fix typos on logging
* Bump to version 0.3.2