### PR TITLE
Ignore Tasks and Versions as Ayon folder types

### DIFF
--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -140,20 +140,24 @@ def create_sg_entities_in_ay(
         sg_session (shotgun_api3.Shotgun): Shotgun Session object.
         shotgrid_project (dict): The project owning the Tasks.
     """
+   
+    # Types of SG entities to ignore as Ayon folders
+    ignored_folder_types = {"task", "version"}
 
-    # Add Shotgrid Entities to Project Entity
-    sg_entities = [
+    # Find Shotgrid Entities that are to be treated as folders
+    sg_folder_entities = [
         {"name": entity_type}
         for entity_type, _ in get_sg_project_enabled_entities(
             sg_session,
             shotgrid_project
-        )
+        ) if entity_type.lower() not in ignored_folder_types
     ]
 
-    new_folder_types = sg_entities + project_entity.folder_types
+    new_folder_types = sg_folder_entities + project_entity.folder_types
     # So we can have a specific folder for AssetCategory
     new_folder_types.append({"name": "AssetCategory"})
 
+    # Make sure list items are unique
     new_folder_types = list({
         entity['name']: entity
         for entity in new_folder_types
@@ -180,7 +184,7 @@ def create_sg_entities_in_ay(
     }.values())
     project_entity.task_types = new_task_types
 
-    return sg_entities, sg_steps
+    return sg_folder_entities, sg_steps
 
 
 def get_asset_category(entity_hub, parent_entity, asset_category_name):
@@ -606,7 +610,7 @@ def get_sg_project_enabled_entities(
 
             if parent_field and parent_field != "__flat__":
                 if "," in parent_field:
-                    # This catches instances where the Hirearchy is set to 
+                    # This catches instances where the Hierarchy is set to 
                     # something like "Seq > Secene > Shot" which returns a string
                     # like so: 'sg_scene,Scene.sg_sequence' and confusing enough
                     # we want the first element to be the parent.


### PR DESCRIPTION
The processor was adding 'Version' and 'Task' as folder types although those shouldn't even be versions.

Moreover, there's still a bug where `match_shotgrid_hierarchy_in_ayon` is creating the versions as folder entities:

![image](https://github.com/ynput/ayon-shotgrid/assets/4348536/1c5fce0e-7243-4327-b56c-20b2ba4c8245)

@Minkiu looking at the code I see there's this logic:
```
        # If we couldn't find it we create it.
        if ay_entity is None:
            if sg_entity.get("shotgridType") == "AssetCategory":
                ay_entity = get_asset_category(
                    entity_hub,
                    ay_parent_entity,
                    sg_entity["name"]
                )

            if not ay_entity:
                ay_entity = _create_new_entity(
                    entity_hub,
                    ay_parent_entity,
                    sg_entity
                )
```
We shouldn't be creating the new entity if it's not found right? Should we add a validation on the `if not ay_entity` to ignore those SG entity types too?