### PR TITLE
Fixes for "`settings` Add a map for entity's custom attributes #72"

### DIFF
--- a/client/ayon_shotgrid/addon.py
+++ b/client/ayon_shotgrid/addon.py
@@ -48,7 +48,7 @@ class ShotgridAddon(OpenPypeModule, IPluginPaths):
     def create_shotgrid_session(self):
         from .lib import credentials
 
-        sg_username = os.getenv("AYON_SG_USERNAME")
+        sg_username = os.getenv("USER") or os.getenv("AYON_SG_USER")
         proxy = os.environ.get("HTTPS_PROXY", "").lstrip("https://")
 
         return credentials.create_sg_session(

--- a/client/ayon_shotgrid/plugins/publish/collect_shotgrid_session.py
+++ b/client/ayon_shotgrid/plugins/publish/collect_shotgrid_session.py
@@ -11,10 +11,10 @@ class CollectShotgridSession(pyblish.api.ContextPlugin):
     label = "Collecting Shotgrid session"
 
     def process(self, context):
-        user_login = os.getenv("AYON_SG_USERNAME")
+        user_login = os.getenv("USER") or os.getenv("AYON_SG_USER")
         if not user_login:
             raise KnownPublishError(
-                "Have you logged in into Ayon Tray > Shotgrid?"
+                "User not found in environment, make sure it's set."
             )
 
         shotgrid_module = context.data["openPypeModules"]["shotgrid"]

--- a/server/frontend/dist/index.html
+++ b/server/frontend/dist/index.html
@@ -31,7 +31,7 @@
                 <th>Code</th>
                 <th>In AYON?</th>
                 <th>In Shotgrid?</th>
-                <th>Syncronize</th>
+                <th>Synchronize</th>
             </tr>
         </thead>
         <tbody class="sg-addon-projects-table-body" id="sg-addon-projects-table-body">

--- a/server/frontend/dist/shotgrid-addon.js
+++ b/server/frontend/dist/shotgrid-addon.js
@@ -39,7 +39,7 @@ const init = () => {
 
 const populateTable = async () => {
   /* Get all the projects from AYON and Shotgrid, then populate the table with their info
-  and a button to Syncronize if they pass the requirements */
+  and a button to Synchronize if they pass the requirements */
   ayonProjects = await getAyonProjects();
   sgProjects = await getShotgridProjects();
 

--- a/services/processor/processor/handlers/sync_projects.py
+++ b/services/processor/processor/handlers/sync_projects.py
@@ -14,7 +14,7 @@ def process_event(
     sg_processor,
     **kwargs,
 ):
-    """Syncronize a project between AYON and Shotgrid.
+    """Synchronize a project between AYON and Shotgrid.
 
     Events with the action `sync-from-shotgrid` or `sync-from-ayon` will trigger
     this function, where we travees a whole project, either in Shotgrid or AYON,
@@ -33,7 +33,7 @@ def process_event(
 
     # This will ensure that the project exists in both platforms.
     hub.create_project()
-    hub.syncronize_projects(
+    hub.synchronize_projects(
         source="ayon" if kwargs.get("action") == "sync-from-ayon" else "shotgrid"
     )
 

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -326,7 +326,9 @@ class AyonShotgridHub:
 
             case "attribute_change":
                 if sg_event["attribute_name"] not in self.custom_attributes_map.values():
-                    logging.warning("Can't handle this attribute.")
+                    logging.warning(
+                        "Updating attribute '%s' from SG to Ayon not supported.", sg_event["attribute_name"]
+                    )
                     return
                 update_ayon_entity_from_sg_event(
                     sg_event,
@@ -388,7 +390,17 @@ class AyonShotgridHub:
                     self._sg,
                     self._ay_project,
                 )
-
+            case "entity.task.attrib_changed" | "entity.folder.attrib_changed":
+                attrib_key = next(iter(ayon_event["payload"]["newValue"]))
+                if attrib_key not in self.custom_attributes_map:
+                    logging.warning("Updating attribute '%s' from Ayon to SG not supported: %s.", attrib_key, self.custom_attributes_map)
+                    return
+                update_sg_entity_from_ayon_event(
+                    ayon_event,
+                    self._sg,
+                    self._ay_project,
+                    self.custom_attributes_map
+                )
             case _:
                 msg = f"Unable to process event {ayon_event['topic']}."
                 logging.error(msg)

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -48,7 +48,7 @@ class AyonShotgridHub:
     """A Hub to manage a Project in both AYON and Shotgrid
 
     Provided a correct project name and code, we attempt to initialize both APIs
-    and ensures that both platforms have the required elements to syncronize a
+    and ensures that both platforms have the required elements to synchronize a
     project across them.
 
     The Shotgrid credentials must have enough permissions to add fields to
@@ -225,7 +225,7 @@ class AyonShotgridHub:
         self.create_sg_attributes()
         logging.info(f"Project {self.project_name} ({self.project_code}) available in SG and AYON.")
 
-    def syncronize_projects(self, source="ayon"):
+    def synchronize_projects(self, source="ayon"):
         """ Ensure a Project matches in the other platform.
 
         Args:

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -5,20 +5,13 @@ This service will continually run and query the Ayon Events Server in order to
 entroll the events of topic `entity.folder` and `entity.task` when any of the
 two are `created`, `renamed` or `deleted`.
 """
-# import importlib
-import os
-import sys
 import time
-# import types
-import signal
 import socket
 
 from ayon_shotgrid_hub import AyonShotgridHub
 
 import ayon_api
-from ayon_api.entity_hub import EntityHub
 from nxtools import logging, log_traceback
-import shotgun_api3
 
 
 class ShotgridTransmitter:
@@ -45,6 +38,11 @@ class ShotgridTransmitter:
             self.sg_api_key = sg_secret.get("value")
             self.ayon_service_user = self.settings["service_settings"]["ayon_service_user"]
 
+            self.custom_attributes_map = {
+                attr["ayon"]: attr["sg"]
+                for attr in self.settings["compatibility_settings"]["custom_attributes_map"]
+                if attr["sg"]
+            }
             try:
                 self.sg_polling_frequency = int(
                     self.settings["service_settings"]["polling_frequency"]
@@ -156,6 +154,7 @@ class ShotgridTransmitter:
                     self.sg_api_key,
                     self.sg_script_name,
                     sg_project_code_field=self.sg_project_code_field,
+                    custom_attributes_map=self.custom_attributes_map,
                 )
 
                 hub.react_to_ayon_event(source_event)


### PR DESCRIPTION
A few bug fixes on top of https://github.com/ynput/ayon-shotgrid/pull/72

* Duplicated tasks from SG fail to sync to Ayon and because of how the system is designed the whole thing blocks from syncing more things. This now avoids trying to create entities that have the same name under the same parent... although that's still not ideal as that will create an out of sync behavior with Shotgrid DB and won't allow us to update the task. Ideally Ayon wouldn't have the limitation of task names needing to be unique as I have said in the past also with products https://community.ynput.io/t/restriction-of-uniqueness-of-product-names/1232 ... but alternatively, we need to figure out a way to show the user that there's a duplicated task and they need to rename it in SG if they want it synced and not get weird behaviors...
* Add support to catch attrib_changed events from Ayon so they sync to SG

Other questions for @Ynput:

* Why are `status` and `tags` changes on the entities not firing any events?
* Custom attributes don't map to the same field on all entities in SG as some of those are built-in and some aren't and the non-built-in start with `sg_`  (i.e., `sg_start_date`)... whereas the built-in ones don't (i.e., `start_date`) so we would need to either check whether the optional `sg_` prefix exists or allow for setting different custom attributes per entity...