### PR TITLE
Custom attributes mapping with type and scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ make SERVICE=<service-name> dev
 You should now see something similar to:
 ```sh
 INFO       Initializing the Shotgrid Processor.
-DEBUG      Found the these handlers: {'create-project': [<module 'project_sync'>], 'sync-from-shotgrid': [<module 'sync_from_shotgrid'>], 'shotgrid-event': [<module 'update_from_shotgrid'>]}
+DEBUG      Found these handlers: {'create-project': [<module 'project_sync'>], 'sync-from-shotgrid': [<module 'sync_from_shotgrid'>], 'shotgrid-event': [<module 'update_from_shotgrid'>]}
 INFO       Start enrolling for Ayon `shotgrid.event` Events...
 INFO       Querying for new `shotgrid.event` events...
 INFO       No event of origin `shotgrid.event` is pending. 

--- a/server/frontend/dist/shotgrid-addon.css
+++ b/server/frontend/dist/shotgrid-addon.css
@@ -23,52 +23,52 @@ select {
 }
 
 table {
-table-layout: fixed;
-width: 100%;
-border-collapse: collapse;
-border: 4px solid #2C313A;
-margin-top: 25px;
+  table-layout: fixed;
+  width: 100%;
+  border-collapse: collapse;
+  border: 4px solid #2C313A;
+  margin-top: 25px;
 }
 
 thead {
-text-align: left;
-background-color: #384956;
+  text-align: left;
+  background-color: #384956;
 }
 
 thead th:nth-child(1) {
-width: 25%;
+  width: 25%;
 }
 
 thead th:nth-child(2) {
-width: 25%;
+  width: 25%;
 }
 
 thead th:nth-child(3) {
-width: 10%;
+  width: 10%;
 }
 
 thead th:nth-child(4) {
-width: 10%;
+  width: 10%;
 }
 
 thead th:nth-child(5) {
-width: 30%;
+  width: 30%;
 }
 
 tbody td {
-text-align: left;
-border: 3px solid #2C313A;
+  text-align: left;
+  border: 3px solid #2C313A;
 }
 
 th,
 td {
-border: 3px solid #2C313A;
+  border: 3px solid #2C313A;
 }
 
 table tr:not(:first-child):nth-child(odd) {
-background-color: #414957;
+  background-color: #414957;
 }
 
 table tr:nth-child(even) {
-background-color: #2c313a;
+  background-color: #2c313a;
 }

--- a/server/frontend/dist/shotgrid-addon.css
+++ b/server/frontend/dist/shotgrid-addon.css
@@ -1,79 +1,74 @@
 body {
-    padding: 0 20px;
-    background: #21252b;;
-    color: #ccc;
-    font-family: sans-serif;
+  padding: 0 20px;
+  background: #21252b;;
+  color: #ccc;
+  font-family: sans-serif;
 }
 
 iframe > html {
-    border-radius: 5px;
+  border-radius: 5px;
 }
 
 fieldset {
-    border-color: #252323;
-    margin-bottom: 20px;
+  border-color: #252323;
+  margin-bottom: 20px;
 }
 
 h2 {
-    margin-top: 40px;
+  margin-top: 40px;
 }
 
 select {
-    margin-top: 10px;
+  margin-top: 10px;
 }
 
 table {
-  table-layout: fixed;
-  width: 100%;
-  border-collapse: collapse;
-  border: 4px solid #2C313A;
-  margin-top: 25px;
+table-layout: fixed;
+width: 100%;
+border-collapse: collapse;
+border: 4px solid #2C313A;
+margin-top: 25px;
 }
 
 thead {
-    text-align: left;
-    background-color: #2C313A;
+text-align: left;
+background-color: #384956;
 }
 
 thead th:nth-child(1) {
-  width: 20%;
+width: 25%;
 }
 
 thead th:nth-child(2) {
-  width: 20%;
+width: 25%;
 }
 
 thead th:nth-child(3) {
-  width: 20%;
+width: 10%;
 }
 
 thead th:nth-child(4) {
-  width: 20%;
+width: 10%;
 }
 
 thead th:nth-child(5) {
-  width: 35%;
+width: 30%;
 }
 
 tbody td {
-  text-align: left;
-  border: 3px solid #2C313A;
+text-align: left;
+border: 3px solid #2C313A;
 }
 
 th,
 td {
-  border: 3px solid #2C313A;
+border: 3px solid #2C313A;
 }
 
-tbody tr:nth-child(odd) {
-  background-color: var(--gray-50);
+table tr:not(:first-child):nth-child(odd) {
+background-color: #414957;
 }
 
-tbody tr:nth-child(even) {
-  background-color: #2C313A;
+table tr:nth-child(even) {
+background-color: #2c313a;
 }
-
-.populate-table-button {
-    margin-top: 20px;
-}
-

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -122,7 +122,7 @@ class ShotGridCompatibilitySettings(BaseSettingsModel):
         title="Folder Attributes Map",
         default_factory=get_default_folder_attributes,
         description=(
-          "AYON attributes <> Shotgrid fields (without 'sg_' prefix!) "
+          "AYON attributes <> ShotGrid fields (without 'sg_' prefix!) "
           "mapping. Empty ones will be ignored."
         ),
     )

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -8,19 +8,23 @@ def get_default_folder_attributes():
 
     Get all the `attribs` for Folder entities in a list
     to be consumed by the `default_factory` in the
-    `ShotgridCompatibilitySettings.custom_attributes_map`
+    `ShotgridCompatibilitySettings.custom_attribs_map`
     settings.
     """
     attributes = []
 
     for attr_dict in attribute_library.data.get("folder", {}):
         attr_name = attr_dict["name"]
-        attr_title = attr_dict["title"]
 
         if attr_name in ["shotgridId", "shotgridType", "tools"]:
             continue
 
-        attr_map = {"ayon": attr_name, "sg": "" }
+        attr_map = {
+            "ayon": attr_name,
+            "sg": "",
+            "type": [attr_dict["type"]],
+            "scope": default_shotgrid_entities()
+        }
 
         if attr_map not in attributes:
             attributes.append(attr_map)
@@ -65,7 +69,25 @@ class ShotgridServiceSettings(BaseSettingsModel):
 class AttributesMappingModel(BaseSettingsModel):
     _layout = "compact"
     ayon: str = SettingsField(title="AYON")
-    sg: str = SettingsField(title="Shotgrid")
+    sg: str = SettingsField(title="SG")
+    # TODO: how do you make this a single selectable entry
+    type: list[str] = SettingsField(
+        title="Type",
+        default_factory=list,
+        enum_resolver=lambda: [
+            "string",
+            "integer",
+            "float",
+            "list_of_strings",
+            "boolean",
+            "datetime",
+        ]
+    )
+    scope: list[str] = SettingsField(
+        title="Scope",
+        default_factory=list,
+        enum_resolver=default_shotgrid_entities
+    )
 
 
 class ShotgridCompatibilitySettings(BaseSettingsModel):
@@ -85,10 +107,10 @@ class ShotgridCompatibilitySettings(BaseSettingsModel):
         description="The Entities that are enabled in Shotgrid, disable any that you do not use."
     )
 
-    custom_attributes_map: list[AttributesMappingModel] = SettingsField(
+    custom_attribs_map: list[AttributesMappingModel] = SettingsField(
         title="Folder Attributes Map",
         default_factory=get_default_folder_attributes,
-        description="AYON Folder's attributes <> Shotgird fields mapping, empty ones will be ignored.",
+        description="AYON attributes <> Shotgrid fields (without 'sg_' prefix!) mapping. Empty ones will be ignored.",
     )
 
 

--- a/services/processor/processor/handlers/shotgrid_event.py
+++ b/services/processor/processor/handlers/shotgrid_event.py
@@ -34,7 +34,8 @@ def process_event(
         sg_processor.sg_api_key,
         sg_processor.sg_script_name,
         sg_project_code_field=sg_processor.sg_project_code_field,
-        custom_attributes_map=sg_processor.custom_attributes_map,
+        custom_attribs_map=sg_processor.custom_attribs_map,
+        custom_attribs_types=sg_processor.custom_attribs_types,
         sg_enabled_entities=sg_processor.sg_enabled_entities,
     )
 

--- a/services/processor/processor/handlers/sync_projects.py
+++ b/services/processor/processor/handlers/sync_projects.py
@@ -27,7 +27,8 @@ def process_event(
         sg_processor.sg_api_key,
         sg_processor.sg_script_name,
         sg_project_code_field=sg_processor.sg_project_code_field,
-        custom_attributes_map=sg_processor.custom_attributes_map,
+        custom_attribs_map=sg_processor.custom_attribs_map,
+        custom_attribs_types=sg_processor.custom_attribs_types,
         sg_enabled_entities=sg_processor.sg_enabled_entities,
     )
 

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -55,9 +55,14 @@ class ShotgridProcessor:
             except Exception:
                 self.sg_polling_frequency = 10
 
-            self.custom_attributes_map = {
+            self.custom_attribs_map = {
                 attr["ayon"]: attr["sg"]
-                for attr in self.settings["compatibility_settings"]["custom_attributes_map"]
+                for attr in self.settings["compatibility_settings"]["custom_attribs_map"]
+                if attr["sg"]
+            }
+            self.custom_attribs_types = {
+                attr["sg"]: (attr["type"], attr["scope"])
+                for attr in self.settings["compatibility_settings"]["custom_attribs_map"]
                 if attr["sg"]
             }
             self.sg_enabled_entities = self.settings["compatibility_settings"]["shotgrid_enabled_entities"]
@@ -77,7 +82,7 @@ class ShotgridProcessor:
         if not self.handlers_map:
             logging.error("No handlers found for the processor, aborting.")
         else:
-            logging.debug(f"Found the these handlers: {self.handlers_map}")
+            logging.debug(f"Found these handlers: {self.handlers_map}")
 
     def _get_handlers(self):
         """ Import the handlers found in the `handlers` directory.

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -338,6 +338,10 @@ class AyonShotgridHub:
             sg_event (dict): The `meta` key of a ShotGrid Event, describing what
                 the change encompasses, i.e. a new shot, new asset, etc.
         """
+        if not self._ay_project:
+            logging.info(f"Ignoring event, AYON project {self.project_name} not found.")
+            return
+
         match sg_event["type"]:
             case "new_entity" | "entity_revival":
                 create_ay_entity_from_sg_event(

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -93,6 +93,7 @@ class AyonShotgridHub:
             self.sg_project_code_field = sg_project_code_field
         else:
             self.sg_project_code_field = "code"
+            
         self.custom_attribs_map = {
             "status": "status_list",
             "tags": "tags"
@@ -181,11 +182,10 @@ class AyonShotgridHub:
 
         custom_fields = [
             self.sg_project_code_field,
-            CUST_FIELD_CODE_AUTO_SYNC
+            CUST_FIELD_CODE_AUTO_SYNC,
         ]
-        if self.custom_attribs_map:
-            for attrib in self.custom_attribs_map.values():
-                custom_fields.extend([f"sg_{attrib}", attrib])
+        for attrib in self.custom_attribs_map.values():
+            custom_fields.extend([f"sg_{attrib}", attrib])
 
         try:
             self._sg_project = get_sg_project_by_name(
@@ -244,7 +244,7 @@ class AyonShotgridHub:
                 "Project"
             )
             self._ay_project.commit_changes()
-
+            
         self.create_sg_attributes()
         logging.info(f"Project {self.project_name} ({self.project_code}) available in SG and AYON.")
 

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -220,8 +220,6 @@ class AyonShotgridHub:
             self._ay_project = EntityHub(self.project_name)
             self._ay_project.query_entities_from_server()
 
-            # TODO: add custom attributes on creation
-
         self._ay_project.commit_changes()
 
         if self._sg_project is None:
@@ -246,8 +244,6 @@ class AyonShotgridHub:
                 "Project"
             )
             self._ay_project.commit_changes()
-            
-            # TODO: add custom attributes on creation
 
         self.create_sg_attributes()
         logging.info(f"Project {self.project_name} ({self.project_code}) available in SG and AYON.")

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -275,8 +275,7 @@ class AyonShotgridHub:
                     for entity_name, _ in get_sg_project_enabled_entities(
                         self._sg,
                         self._sg_project,
-                        self.sg_enabled_entities,
-                        self.custom_attribs_map
+                        self.sg_enabled_entities
                     )
                 ]
 

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -53,13 +53,13 @@ def match_ayon_hierarchy_in_shotgrid(
     sg_ay_dicts_deck = collections.deque()
 
     # Append the project's direct children.
-    for sg_ay_dict_child in entity_hub._entities_by_parent_id[entity_hub.project_name]:
+    for ay_entity_child in entity_hub._entities_by_parent_id[entity_hub.project_name]:
         sg_ay_dicts_deck.append((
             get_sg_entity_as_ay_dict(
                 sg_session, "Project", sg_project["id"], project_code_field,
                 custom_attribs_map=custom_attribs_map
             ),
-            sg_ay_dict_child
+            ay_entity_child
         ))
 
     ay_project_sync_status = "Synced"

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -182,7 +182,7 @@ def _create_new_entity(
     sg_parent_entity,
     sg_enabled_entities,
     project_code_field,
-    custom_attribs_map=None,
+    custom_attribs_map,
 ):
     """Helper method to create entities in Shotgrid.
 

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -142,14 +142,29 @@ def match_ayon_hierarchy_in_shotgrid(
 
         for ay_entity_child in entity_hub._entities_by_parent_id.get(ay_entity.id, []):
             ay_entities_deck.append((sg_entity_dict, ay_entity_child))
+    
+    data_to_update = {
+        CUST_FIELD_CODE_ID: entity_hub.project_name,
+        CUST_FIELD_CODE_SYNC: sg_project_sync_status
+    }
+
+    # Sync project attributes from Ayon to SG
+    if custom_attribs_map:
+        for ay_attrib, sg_attrib in custom_attribs_map.items():
+            if ay_attrib == "status":
+                attrib_value = entity_hub.project_entity.get(ay_attrib)
+            else:
+                attrib_value = entity_hub.project_entity.attribs.get(ay_attrib)
+            
+            if attrib_value is None:
+                continue
+
+            data_to_update[sg_attrib] = attrib_value
 
     sg_session.update(
         "Project",
         sg_project["id"],
-        {
-            CUST_FIELD_CODE_ID: entity_hub.project_name,
-            CUST_FIELD_CODE_SYNC: sg_project_sync_status
-        }
+        data_to_update
     )
 
     entity_hub.project_entity.attribs.set(

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -183,6 +183,19 @@ def match_shotgrid_hierarchy_in_ayon(
         "Project"
     )
 
+    # Sync project attributes from Shotgrid to Ayon
+    if custom_attribs_map:
+        for ay_attrib, sg_attrib in custom_attribs_map.items():
+            attrib_value = sg_entity["attribs"].get(sg_attrib) \
+                or sg_entity["attribs"].get(f"sg_{sg_attrib}")
+            if attrib_value is None:
+                continue
+
+            entity_hub.project_entity.attribs.set(
+                ay_attrib,
+                attrib_value
+            )
+
     entity_hub.commit_changes()
 
     sg_session.update(

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -9,7 +9,11 @@ from constants import (
     SHOTGRID_TYPE_ATTRIB,
 )
 
-from utils import get_sg_entities, get_asset_category
+from utils import (
+    get_sg_entities,
+    get_asset_category,
+    update_ay_entity_custom_attributes,
+)
 
 from nxtools import logging, log_traceback
 
@@ -20,7 +24,7 @@ def match_shotgrid_hierarchy_in_ayon(
     sg_session,
     sg_enabled_entities,
     project_code_field,
-    custom_attribs_map=None,
+    custom_attribs_map,
 ):
     """Replicate a Shotgrid project into AYON.
 
@@ -35,54 +39,39 @@ def match_shotgrid_hierarchy_in_ayon(
         sg_project (shotgun_api3.Shotgun): The Shotgrid session.
         project_code_field (str): The Shotgrid project code field.
     """
-    custom_fields = []
-    if custom_attribs_map:
-        for sg_attrib in custom_attribs_map.values():
-            custom_fields.extend([f"sg_{sg_attrib}", sg_attrib])
-
-    sg_entities_by_id, sg_entities_by_parent_id = get_sg_entities(
+    logging.info("Getting Shotgrid entities.")
+    sg_ay_dicts, sg_ay_dicts_parents = get_sg_entities(
         sg_session,
         sg_project,
         sg_enabled_entities,
-        custom_fields=custom_fields,
-        project_code_field=project_code_field,
-        custom_attribs_map=custom_attribs_map,
+        project_code_field,
+        custom_attribs_map,
     )
 
-    sg_entities_deck = collections.deque()
+    sg_ay_dicts_deck = collections.deque()
 
     # Append the project's direct children.
-    for sg_project_child in sg_entities_by_parent_id[sg_project["id"]]:
-        sg_entities_deck.append((entity_hub.project_entity, sg_project_child))
+    for sg_ay_dict_child in sg_ay_dicts_parents[sg_project["id"]]:
+        sg_ay_dicts_deck.append((entity_hub.project_entity, sg_ay_dict_child))
 
     sg_project_sync_status = "Synced"
 
-    while sg_entities_deck:
-        (ay_parent_entity, sg_entity) = sg_entities_deck.popleft()
-        logging.debug(f"Processing {sg_entity} with parent {ay_parent_entity}")
+    while sg_ay_dicts_deck:
+        (ay_parent_entity, sg_ay_dict) = sg_ay_dicts_deck.popleft()
+        logging.debug(f"Processing {sg_ay_dict} with parent {ay_parent_entity}")
 
         ay_entity = None
         sg_entity_sync_status = "Synced"
 
-        ay_id = sg_entity["data"].get(CUST_FIELD_CODE_ID)
-
+        ay_id = sg_ay_dict["data"].get(CUST_FIELD_CODE_ID)
         if ay_id:
             ay_entity = entity_hub.get_or_query_entity_by_id(
-                ay_id, [sg_entity["type"]])
+                ay_id, [sg_ay_dict["type"]])
 
         # If we haven't found the ay_entity by its id, check by its name
         # to avoid creating duplicates and erroring out
         if ay_entity is None:
-            name = slugify_string(sg_entity["name"])
-            for child in ay_parent_entity.children:
-                if child.name.lower() == name.lower():
-                    ay_entity = child
-                    break
-
-        # If we haven't found the ay_entity by its id, check by its name
-        # to avoid creating duplicates and erroring out
-        if ay_entity is None:
-            name = slugify_string(sg_entity["name"])
+            name = slugify_string(sg_ay_dict["name"])
             for child in ay_parent_entity.children:
                 if child.name.lower() == name.lower():
                     ay_entity = child
@@ -90,18 +79,18 @@ def match_shotgrid_hierarchy_in_ayon(
 
         # If we couldn't find it we create it.
         if ay_entity is None:
-            if sg_entity["attribs"].get(SHOTGRID_TYPE_ATTRIB) == "AssetCategory":  # noqa
+            if sg_ay_dict["attribs"].get(SHOTGRID_TYPE_ATTRIB) == "AssetCategory":  # noqa
                 ay_entity = get_asset_category(
                     entity_hub,
                     ay_parent_entity,
-                    sg_entity["name"]
+                    sg_ay_dict["name"]
                 )
 
             if not ay_entity:
                 ay_entity = _create_new_entity(
                     entity_hub,
                     ay_parent_entity,
-                    sg_entity
+                    sg_ay_dict
                 )
         else:
             logging.debug(
@@ -109,95 +98,82 @@ def match_shotgrid_hierarchy_in_ayon(
                 "Making sure the stored Shotgrid Data matches."
             )
 
-            ay_shotgrid_id_attrib = ay_entity.attribs.get(
+            ay_sg_id_attrib = ay_entity.attribs.get(
                 SHOTGRID_ID_ATTRIB
             )
 
-            if ay_shotgrid_id_attrib != str(sg_entity["attribs"][SHOTGRID_ID_ATTRIB]): # noqa
+            if ay_sg_id_attrib != str(sg_ay_dict["attribs"][SHOTGRID_ID_ATTRIB]): # noqa
                 logging.error(
                     f"The AYON entity {ay_entity.name} <{ay_entity.id}> has the "  # noqa
-                    f"ShotgridId {ay_shotgrid_id_attrib}, while the Shotgrid ID "  # noqa
-                    f"should be {sg_entity['attribs'][SHOTGRID_ID_ATTRIB]}"
+                    f"ShotgridId {ay_sg_id_attrib}, while the Shotgrid ID "  # noqa
+                    f"should be {sg_ay_dict['attribs'][SHOTGRID_ID_ATTRIB]}"
                 )
                 sg_entity_sync_status = "Failed"
                 sg_project_sync_status = "Failed"
-                continue
-        
-        if custom_attribs_map:
-            for ay_attr, sg_attr in custom_attribs_map.items():
-                sg_value = sg_entity.get(sg_attr) or sg_entity.get(f"sg_{sg_attr}")
-
-                # If no value in SG entity skip
-                if sg_value is None:
-                    logging.debug(
-                        f"Couldn't find value for '{sg_attr}' in entity '{sg_entity['name']}'"
-                    )
-                    continue
-                
-                # TODO: Is this + commit_changes enough to update the ayon entity?
-                ay_entity.attribs[ay_attr] = sg_value
+            else:
+                update_ay_entity_custom_attributes(
+                    ay_entity, sg_ay_dict, custom_attribs_map
+                )
 
         # Update SG entity with new created data
-        sg_entity["data"][CUST_FIELD_CODE_ID] = ay_entity.id
-        sg_entities_by_id[sg_entity["attribs"][SHOTGRID_ID_ATTRIB]] = sg_entity
+        sg_ay_dict["data"][CUST_FIELD_CODE_ID] = ay_entity.id
+        sg_ay_dicts[sg_ay_dict["attribs"][SHOTGRID_ID_ATTRIB]] = sg_ay_dict
 
-        entity_id = sg_entity["name"]
+        entity_id = sg_ay_dict["name"]
 
-        if sg_entity["attribs"][SHOTGRID_TYPE_ATTRIB] not in [
+        if sg_ay_dict["attribs"][SHOTGRID_TYPE_ATTRIB] not in [
                 "Folder", "AssetCategory"]:
             if (
-                sg_entity["data"][CUST_FIELD_CODE_ID] != ay_entity.id
-                or sg_entity["data"][CUST_FIELD_CODE_SYNC] != sg_entity_sync_status  # noqa
+                sg_ay_dict["data"][CUST_FIELD_CODE_ID] != ay_entity.id
+                or sg_ay_dict["data"][CUST_FIELD_CODE_SYNC] != sg_entity_sync_status  # noqa
             ):
                 update_data = {
                     CUST_FIELD_CODE_ID: ay_entity.id,
-                    CUST_FIELD_CODE_SYNC: sg_entity["data"][CUST_FIELD_CODE_SYNC]  # noqa
+                    CUST_FIELD_CODE_SYNC: sg_ay_dict["data"][CUST_FIELD_CODE_SYNC]  # noqa
                 }
                 sg_session.update(
-                    sg_entity["attribs"][SHOTGRID_TYPE_ATTRIB],
-                    sg_entity["attribs"][SHOTGRID_ID_ATTRIB],
+                    sg_ay_dict["attribs"][SHOTGRID_TYPE_ATTRIB],
+                    sg_ay_dict["attribs"][SHOTGRID_ID_ATTRIB],
                     update_data
                 )
 
-            entity_id = sg_entity["attribs"][SHOTGRID_ID_ATTRIB]
+            entity_id = sg_ay_dict["attribs"][SHOTGRID_ID_ATTRIB]
 
         try:
             entity_hub.commit_changes()
         except Exception as e:
-            logging.error(f"Unable to create entity {sg_entity} in AYON!")
+            logging.error(f"Unable to create entity {sg_ay_dict} in AYON!")
             log_traceback(e)
 
         # If the entity has children, add it to the deck
-        for sg_child in sg_entities_by_parent_id.get(
-            entity_id, []
-        ):
-            sg_entities_deck.append((ay_entity, sg_child))
+        for sg_child in sg_ay_dicts_parents.get(entity_id, []):
+            sg_ay_dicts_deck.append((ay_entity, sg_child))
 
+    # Sync project attributes from Shotgrid to AYON
     entity_hub.project_entity.attribs.set(
         SHOTGRID_ID_ATTRIB,
         sg_project["id"]
     )
-
     entity_hub.project_entity.attribs.set(
         SHOTGRID_TYPE_ATTRIB,
         "Project"
     )
+    for ay_attrib, sg_attrib in custom_attribs_map.items():
+        attrib_value = sg_project.get(sg_attrib) \
+            or sg_project.get(f"sg_{sg_attrib}")
+        
+        logging.debug(f"Checking {sg_attrib} -> {attrib_value}")
+        if attrib_value is None:
+            continue
 
-    # Sync project attributes from Shotgrid to Ayon
-    if custom_attribs_map:
-        for ay_attrib, sg_attrib in custom_attribs_map.items():
-            attrib_value = sg_entity["attribs"].get(sg_attrib) \
-                or sg_entity["attribs"].get(f"sg_{sg_attrib}")
-            if attrib_value is None:
-                continue
-
-            entity_hub.project_entity.attribs.set(
-                ay_attrib,
-                attrib_value
-            )
+        entity_hub.project_entity.attribs.set(
+            ay_attrib,
+            attrib_value
+        )
 
     entity_hub.commit_changes()
 
+    # Update Shotgrid project with Ayon ID and sync status
     sg_session.update(
         "Project",
         sg_project["id"],
@@ -208,7 +184,7 @@ def match_shotgrid_hierarchy_in_ayon(
     )
 
 
-def _create_new_entity(entity_hub, parent_entity, sg_entity):
+def _create_new_entity(entity_hub, parent_entity, sg_ay_dict):
     """Helper method to create entities in the EntityHub.
 
     Task Creation:
@@ -221,29 +197,29 @@ def _create_new_entity(entity_hub, parent_entity, sg_entity):
     Args:
         entity_hub (ayon_api.EntityHub): The project's entity hub.
         parent_entity: Ayon parent entity.
-        sg_entity (dict): Shotgrid entity to create.
+        sg_ay_dict (dict): Ayon ShotGrid entity to create.
     """
-    if sg_entity["type"].lower() == "task":
-        new_entity = entity_hub.add_new_task(
-            sg_entity["task_type"],
-            name=sg_entity["name"],
-            label=sg_entity["label"],
-            entity_id=sg_entity["data"][CUST_FIELD_CODE_ID],
+    if sg_ay_dict["type"].lower() == "task":
+        ay_entity = entity_hub.add_new_task(
+            sg_ay_dict["task_type"],
+            name=sg_ay_dict["name"],
+            label=sg_ay_dict["label"],
+            entity_id=sg_ay_dict["data"][CUST_FIELD_CODE_ID],
             parent_id=parent_entity.id,
-            attribs=sg_entity["attribs"],
-            data=sg_entity["data"],
+            attribs=sg_ay_dict["attribs"],
+            data=sg_ay_dict["data"],
         )
     else:
-        new_entity = entity_hub.add_new_folder(
-            sg_entity["folder_type"],
-            name=sg_entity["name"],
-            label=sg_entity["label"],
-            entity_id=sg_entity["data"][CUST_FIELD_CODE_ID],
+        ay_entity = entity_hub.add_new_folder(
+            sg_ay_dict["folder_type"],
+            name=sg_ay_dict["name"],
+            label=sg_ay_dict["label"],
+            entity_id=sg_ay_dict["data"][CUST_FIELD_CODE_ID],
             parent_id=parent_entity.id,
-            attribs=sg_entity["attribs"],
-            data=sg_entity["data"],
+            attribs=sg_ay_dict["attribs"],
+            data=sg_ay_dict["data"],
         )
 
-    logging.debug(f"Created new entity: {new_entity.name} ({new_entity.id})")
+    logging.debug(f"Created new entity: {ay_entity.name} ({ay_entity.id})")
     logging.debug(f"Parent is: {parent_entity.name} ({parent_entity.id})")
-    return new_entity
+    return ay_entity

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -128,9 +128,10 @@ def match_shotgrid_hierarchy_in_ayon(
             sg_ay_dict["data"][CUST_FIELD_CODE_ID] != ay_entity.id
             or sg_ay_dict["data"][CUST_FIELD_CODE_SYNC] != sg_entity_sync_status  # noqa
         ):
+            logging.debug("Updating AYON entity ID and sync status in SG and AYON")
             update_data = {
                 CUST_FIELD_CODE_ID: ay_entity.id,
-                CUST_FIELD_CODE_SYNC: sg_ay_dict["data"][CUST_FIELD_CODE_SYNC]  # noqa
+                CUST_FIELD_CODE_SYNC: sg_entity_sync_status
             }
             sg_session.update(
                 sg_ay_dict["attribs"][SHOTGRID_TYPE_ATTRIB],
@@ -145,7 +146,7 @@ def match_shotgrid_hierarchy_in_ayon(
             )
             ay_entity.data.set(
                 CUST_FIELD_CODE_SYNC,
-                sg_ay_dict["data"][CUST_FIELD_CODE_SYNC]
+                sg_entity_sync_status
             )
 
         try:

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -15,7 +15,12 @@ from nxtools import logging, log_traceback
 
 
 def match_shotgrid_hierarchy_in_ayon(
-    entity_hub, sg_project, sg_session, sg_enabled_entities, project_code_field
+    entity_hub,
+    sg_project,
+    sg_session,
+    sg_enabled_entities,
+    project_code_field,
+    custom_attribs_map=None,
 ):
     """Replicate a Shotgrid project into AYON.
 
@@ -30,12 +35,18 @@ def match_shotgrid_hierarchy_in_ayon(
         sg_project (shotgun_api3.Shotgun): The Shotgrid session.
         project_code_field (str): The Shotgrid project code field.
     """
+    custom_fields = []
+    if custom_attribs_map:
+        for sg_attrib in custom_attribs_map.values():
+            custom_fields.extend([f"sg_{sg_attrib}", sg_attrib])
 
     sg_entities_by_id, sg_entities_by_parent_id = get_sg_entities(
         sg_session,
         sg_project,
         sg_enabled_entities,
-        project_code_field=project_code_field
+        custom_fields=custom_fields,
+        project_code_field=project_code_field,
+        custom_attribs_map=custom_attribs_map,
     )
 
     sg_entities_deck = collections.deque()
@@ -68,6 +79,15 @@ def match_shotgrid_hierarchy_in_ayon(
                     ay_entity = child
                     break
 
+        # If we haven't found the ay_entity by its id, check by its name
+        # to avoid creating duplicates and erroring out
+        if ay_entity is None:
+            name = slugify_string(sg_entity["name"])
+            for child in ay_parent_entity.children:
+                if child.name.lower() == name.lower():
+                    ay_entity = child
+                    break
+
         # If we couldn't find it we create it.
         if ay_entity is None:
             if sg_entity["attribs"].get(SHOTGRID_TYPE_ATTRIB) == "AssetCategory":  # noqa
@@ -89,9 +109,9 @@ def match_shotgrid_hierarchy_in_ayon(
                 "Making sure the stored Shotgrid Data matches."
             )
 
-            ay_shotgrid_id_attrib = ay_entity.attribs.get_attribute(
+            ay_shotgrid_id_attrib = ay_entity.attribs.get(
                 SHOTGRID_ID_ATTRIB
-            ).value
+            )
 
             if ay_shotgrid_id_attrib != str(sg_entity["attribs"][SHOTGRID_ID_ATTRIB]): # noqa
                 logging.error(
@@ -102,6 +122,20 @@ def match_shotgrid_hierarchy_in_ayon(
                 sg_entity_sync_status = "Failed"
                 sg_project_sync_status = "Failed"
                 continue
+        
+        if custom_attribs_map:
+            for ay_attr, sg_attr in custom_attribs_map.items():
+                sg_value = sg_entity.get(sg_attr) or sg_entity.get(f"sg_{sg_attr}")
+
+                # If no value in SG entity skip
+                if sg_value is None:
+                    logging.debug(
+                        f"Couldn't find value for '{sg_attr}' in entity '{sg_entity['name']}'"
+                    )
+                    continue
+                
+                # TODO: Is this + commit_changes enough to update the ayon entity?
+                ay_entity.attribs[ay_attr] = sg_value
 
         # Update SG entity with new created data
         sg_entity["data"][CUST_FIELD_CODE_ID] = ay_entity.id

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -148,14 +148,6 @@ def match_shotgrid_hierarchy_in_ayon(
                 )
 
             entity_id = sg_ay_dict["attribs"][SHOTGRID_ID_ATTRIB]
-            ay_entity.data.set(
-                CUST_FIELD_CODE_ID,
-                ay_entity.id
-            )
-            ay_entity.data.set(
-                CUST_FIELD_CODE_SYNC,
-                sg_entity_sync_status
-            )
 
         try:
             entity_hub.commit_changes()

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
@@ -144,7 +144,7 @@ def update_sg_entity_from_ayon_event(
         new_attribs = ayon_event["payload"].get("newValue")
         # If payload newValue is a dict it means it's an attribute update
         if isinstance(new_attribs, dict):
-            new_attribs = {"attribs": new_attribs}
+            new_attribs = new_attribs["attribs"]
         # Otherwise it's a tag/status update
         else:
             if ayon_event["topic"].endswith("status_changed"):
@@ -342,7 +342,7 @@ def _create_sg_entity(
     # Fill up data with any extra attributes from Ayon we want to sync to SG
     data.update(get_sg_custom_attributes_data(
         sg_session,
-        ay_entity,
+        ay_entity.attribs.to_dict(),
         sg_type,
         custom_attribs_map
     ))

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -253,13 +253,8 @@ def update_ayon_entity_from_sg_event(
     logging.debug("Updating Ayon entity with '%s'" % sg_entity_dict)
     ay_entity.name = sg_entity_dict["name"]
     ay_entity.label = sg_entity_dict["label"]
-    # TODO: this is not updating the status!
-    ay_entity.status = sg_entity_dict["status"]
 
     for attr, attr_value in sg_entity_dict["attribs"].items():
-        if attr in ["status"]:
-            continue
-
         # TODO: add support for tags
         if attr == "tags":
             continue
@@ -271,7 +266,9 @@ def update_ayon_entity_from_sg_event(
             ),
             None
         )
-        if ay_attr:
+        if attr == "status":
+            ay_entity.status = attr_value
+        elif ay_attr:
             logging.info(
                 f"Setting attribute {ay_attr} with value {attr_value}")
             ay_entity.attribs.set(ay_attr, attr_value)

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -44,7 +44,7 @@ def create_ay_entity_from_sg_event(
     sg_project,
     sg_session,
     ayon_entity_hub,
-    sg_enabled_entites,
+    sg_enabled_entities,
     project_code_field,
     custom_attribs_map=None,
 ):
@@ -57,8 +57,8 @@ def create_ay_entity_from_sg_event(
         ayon_entity_hub (ayon_api.entity_hub.EntityHub): The AYON EntityHub.
         sg_enabled_entities (list[str]): List of entity strings enabled.
         project_code_field (str): The Shotgrid project code field.
-        custom_attribs_map (dict): Dictionary that maps a list of attribute names from
-            Ayon to Shotgrid.
+        custom_attribs_map (dict): Dictionary that maps a list of attribute
+            names from AYON to Shotgrid.
 
     Returns:
         ay_entity (ayon_api.entity_hub.EntityHub.Entity): The newly
@@ -84,7 +84,7 @@ def create_ay_entity_from_sg_event(
         custom_attribs_map=custom_attribs_map,
         extra_fields=extra_fields,
     )
-    logging.debug(f"ShotGrid Entity as AYON dict: {sg_entity_dict}")
+    logging.debug(f"ShotGrid Entity as AYON dict: {sg_ay_dict}")
     if not sg_ay_dict:
         logging.warning(
             "Entity {sg_event['entity_type']} <{sg_event['entity_id']}> "
@@ -107,10 +107,10 @@ def create_ay_entity_from_sg_event(
             # Ensure Ayon Entity has the correct Shotgrid ID
             ay_shotgrid_id = str(
               sg_ay_dict["attribs"].get(SHOTGRID_ID_ATTRIB, ""))
-            if ayon_entity_sg_id != sg_entity_sg_id:
+            if ayon_entity_sg_id != ay_shotgrid_id:
                 ay_entity.attribs.set(
                     SHOTGRID_ID_ATTRIB,
-                    sg_entity_sg_id
+                    ay_shotgrid_id
                 )
                 ay_entity.attribs.set(
                     SHOTGRID_TYPE_ATTRIB,
@@ -249,7 +249,7 @@ def update_ayon_entity_from_sg_event(
     ayon_entity_sg_id = str(
         ay_entity.attribs.get_attribute(SHOTGRID_ID_ATTRIB).value)
     sg_entity_sg_id = str(
-        sg_entity_dict["attribs"].get(SHOTGRID_ID_ATTRIB, "")
+        sg_ay_dict["attribs"].get(SHOTGRID_ID_ATTRIB, "")
     )
     if ayon_entity_sg_id != sg_entity_sg_id:
         logging.error("Mismatching ShotGrid IDs, aborting...")
@@ -300,7 +300,7 @@ def remove_ayon_entity_from_sg_event(
         retired_only=True
     )
 
-    logging.debug(f"ShotGrid Entity as Ay dict: {sg_entity_dict}")
+    logging.debug(f"ShotGrid Entity as Ay dict: {sg_ay_dict}")
     if not sg_ay_dict:
         logging.warning(
             f"Entity {sg_event['entity_type']} <{sg_event['entity_id']}> "
@@ -311,7 +311,7 @@ def remove_ayon_entity_from_sg_event(
             "no longer exists in ShotGrid."
         )
 
-    if not sg_entity_dict["data"].get(CUST_FIELD_CODE_ID):
+    if not sg_ay_dict["data"].get(CUST_FIELD_CODE_ID):
         logging.warning("ShotGrid Missing Ayon ID")
         raise ValueError("ShotGrid Missing Ayon ID")
 

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -95,6 +95,8 @@ def _sg_to_ay_dict(
     elif folder_type:
         sg_ay_dict["folder_type"] = folder_type
 
+    logging.debug(f"Transformed sg_entity as ayon dict: {sg_ay_dict}")
+    
     return sg_ay_dict
 
 
@@ -192,6 +194,9 @@ def create_ay_custom_attribs_in_sg_entity(
         # If it doesn't exist, we create a custom attribute on the
         # SG entity by prefixing it with "sg_"
         if not exists:
+            logging.debug(
+                f"Creating ShotGrid field for {sg_attrib} on entity {sg_entity_type}"
+            )
             get_or_create_sg_field(
                 sg_session,
                 sg_entity_type,
@@ -488,6 +493,8 @@ def get_sg_entities(
     sg_ay_dicts_parents: Dict[str, list] = (
         collections.defaultdict(list)
     )
+
+    logging.debug("---- Query fields %s" % query_fields)
 
     for enabled_entity in project_enabled_entities:
         entity_name, parent_field = enabled_entity

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -939,6 +939,7 @@ def update_ay_entity_custom_attributes(
 
         if ay_attrib == "tags":
             logging.warning("Tags update is not supported yet.")
+            ay_entity.tags = [tag["name"] for tag in attrib_value]
         elif ay_attrib == "status":
             ay_entity.status = attrib_value
         else:

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -285,11 +285,13 @@ def create_sg_entities_in_ay(
     }.values())
     project_entity.folder_types = new_folder_types
 
-    # Add ShotGrid Statuses to Project Entity
+    # Add ShotGrid Statuses to AYON Project Entity
     ay_status_codes = [s.short_name.lower() for s in list(project_entity.statuses)]
-    for status_code, status_name in get_sg_statuses(sg_session).items():
-        if status_code.lower() not in ay_status_codes:
-            project_entity.statuses.create(status_name, short_name=status_code)
+    for sg_entity_type in sg_enabled_entities:
+        for status_code, status_name in get_sg_statuses(sg_session, sg_entity_type).items():
+            if status_code.lower() not in ay_status_codes:
+                project_entity.statuses.create(status_name, short_name=status_code)
+                ay_status_codes.append(status_code)
 
     # Add Project task types by querying ShotGrid Pipeline steps
     sg_steps = [

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -32,8 +32,9 @@ def _sg_to_ay_dict(
 
     Args:
         sg_entity (dict): Shotgun Entity dict representation.
-        project_code_field (str): The Shotgrid project code field.
-        custom_attribs_map (dict): Dictionary that maps names of attributes in AYON to Shotgrid equivalents.
+        project_code_field (str): The ShotGrid project code field.
+        custom_attribs_map (dict): Dictionary that maps names of attributes in
+            AYON to ShotGrid equivalents.
     """
     logging.debug(f"Transforming sg_entity '{sg_entity}' to ayon dict.")
 
@@ -110,9 +111,9 @@ def create_ay_fields_in_sg_entities(
 
     Args:
         sg_session (shotgun_api3.Shotgun): Instance of a ShotGrid API Session.
-        sg_entities (list): List of Shotgrid entities to create the fields in.
+        sg_entities (list): List of ShotGrid entities to create the fields in.
         custom_attribs_map (dict): Dictionary that maps names of attributes in
-            AYON to Shotgrid equivalents.
+            AYON to ShotGrid equivalents.
         custom_attribs_types (dict): Dictionary that contains a tuple for each
             attribute containing the type of data and the scope of the attribute.
     """
@@ -153,13 +154,13 @@ def create_ay_custom_attribs_in_sg_entity(
     custom_attribs_map: dict,
     custom_attribs_types: dict
 ):
-    """Create Ayon custom attributes in Shotgrid entities.
+    """Create Ayon custom attributes in ShotGrid entities.
 
     Args:
-        sg_session (shotgun_api3.Shotgun): Instance of a Shotgrid API Session.
-        sg_entities (list): List of Shotgrid entities to create the fields in.
+        sg_session (shotgun_api3.Shotgun): Instance of a ShotGrid API Session.
+        sg_entities (list): List of ShotGrid entities to create the fields in.
         custom_attribs_map (dict): Dictionary that maps names of attributes in
-            AYON to Shotgrid equivalents.
+            AYON to ShotGrid equivalents.
         custom_attribs_types (dict): Dictionary that contains a tuple for each
             attribute containing the type of data and the scope of the attribute.
     """
@@ -204,14 +205,14 @@ def create_ay_fields_in_sg_project(
     custom_attribs_map: dict,
     custom_attribs_types: dict
 ):
-    """Create Ayon Project fields in Shotgrid.
+    """Create Ayon Project fields in ShotGrid.
 
     This will create Project Unique attributes into ShotGrid.
 
     Args:
         sg_session (shotgun_api3.Shotgun): Instance of a ShotGrid API Session.
         custom_attribs_map (dict): Dictionary that maps names of attributes in
-            AYON to Shotgrid equivalents.
+            AYON to ShotGrid equivalents.
         custom_attribs_types (dict): Dictionary that contains a tuple for each
             attribute containing the type of data and the scope of the attribute.
     """
@@ -376,7 +377,7 @@ def get_or_create_sg_field(
 
     if not attribute_exists:
         logging.debug(
-            f"Shotgrid field {sg_entity_type} > {field_code} does not exist."
+            f"ShotGrid field {sg_entity_type} > {field_code} does not exist."
         )
 
         try:
@@ -440,10 +441,11 @@ def get_sg_entities(
 
     Args:
         sg_session (shotgun_api3.Shotgun): Shotgun Session object.
-        sg_project (dict): The Shotgrid project to query its entities.
-        sg_enabled_entities (list): List of Shotgrid entities to query.
-        project_code_field (str): The Shotgrid project code field.
-        custom_attribs_map (dict): Dictionary that maps names of attributes in AYON to Shotgrid equivalents.
+        sg_project (dict): The ShotGrid project to query its entities.
+        sg_enabled_entities (list): List of ShotGrid entities to query.
+        project_code_field (str): The ShotGrid project code field.
+        custom_attribs_map (dict): Dictionary that maps names of attributes in
+            AYON to ShotGrid equivalents.
         extra_fields (list): List of extra fields to pass to the query.
 
     Returns:
@@ -565,8 +567,9 @@ def get_sg_entity_as_ay_dict(
         sg_session (shotgun_api3.Shotgun): Shotgun Session object.
         sg_type (str): The ShotGrid entity type.
         sg_id (int): ShotGrid ID of the entity to query.
-        project_code_field (str): The Shotgrid project code field.
-        custom_attribs_map (dict): Dictionary that maps names of attributes in AYON to Shotgrid equivalents.
+        project_code_field (str): The ShotGrid project code field.
+        custom_attribs_map (dict): Dictionary that maps names of attributes in
+            AYON to ShotGrid equivalents.
         extra_fields (Optional[list]): List of optional fields to query.
         retired_only (bool): Whether to return only retired entities.
     Returns:
@@ -822,7 +825,7 @@ def get_sg_statuses(
     if sg_entity_type:
         entity_status = sg_session.schema_field_read(sg_entity_type, "sg_status_list")
         sg_statuses = entity_status["sg_status_list"]["properties"]["display_values"]["value"]
-        logging.debug(f"Shotgrid Statuses supported by {sg_entity_type}: {sg_statuses}")
+        logging.debug(f"ShotGrid Statuses supported by {sg_entity_type}: {sg_statuses}")
         return sg_statuses
     
     sg_statuses = {
@@ -884,9 +887,9 @@ def get_sg_custom_attributes_data(
     Args:
         sg_session (shotgun_api3.Shotgun): Instance of a Shotgrid API Session.
         sg_entity (dict): Dictionary that holds the Ayon entity data that we
-            want to sync to Shotgrid.
+            want to sync to ShotGrid.
         custom_attribs_map (dict): Dictionary that maps names of attributes in
-            AYON to Shotgrid equivalents.
+            AYON to ShotGrid equivalents.
     """
     data_to_update = {}
     for ay_attrib, sg_attrib in custom_attribs_map.items():
@@ -919,7 +922,7 @@ def update_ay_entity_custom_attributes(
     custom_attribs_map: dict,
     values_to_update: Optional[list] = None,
 ):
-    """Update Ayon entity custom attributes from Shotgrid dictionary"""
+    """Update Ayon entity custom attributes from ShotGrid dictionary"""
     for ay_attrib, sg_attrib in custom_attribs_map.items():
         if values_to_update and ay_attrib not in values_to_update:
             continue

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -630,9 +630,9 @@ def get_sg_entity_parent_field(
     on projects and their Tracking Settings.
 
     Args:
-        sg_session (shotgun_api3.Shotgun): Shotgun Session object.
-        sg_project (dict): Shotgun Project dict representation.
-        sg_entity_type (str): Shotgun Entity type.
+        sg_session (shotgun_api3.Shotgun): ShotGrid Session object.
+        sg_project (dict): ShotGrid Project dict representation.
+        sg_entity_type (str): ShotGrid Entity type.
 
     Returns:
         sg_parent_field (str): The field that points to the entity parent.
@@ -809,13 +809,15 @@ def get_sg_statuses(
     sg_session: shotgun_api3.Shotgun,
     sg_entity_type: Optional[str] = None
 ) -> dict:
-    """ Get all Statuses on a ShotGrid project.
+    """ Get all supported ShotGrid Statuses.
 
     Args:
-        sg_session (shotgun_api3.Shotgun): Shotgun Session object.
+        sg_session (shotgun_api3.Shotgun): ShotGrid Session object.
+        sg_entity_type (str): ShotGrid Entity type.
 
     Returns:
-        sg_statuses (list[tuple()]): ShotGrid Project Statuses list of tuples.
+        sg_statuses (dict[str, str]): ShotGrid Project Statuses dictionary
+            mapping the status short code and its long name.
     """
     # If given an entity type, we filter out the statuses by just the ones
     # supported by that entity
@@ -833,6 +835,27 @@ def get_sg_statuses(
     }
     logging.debug(f"ShotGrid Statuses: {sg_statuses}")
     return sg_statuses
+
+
+def get_sg_tags(
+    sg_session: shotgun_api3.Shotgun
+) -> dict:
+    """ Get all tags on a ShotGrid project.
+
+    Args:
+        sg_session (shotgun_api3.Shotgun): ShotGrid Session object.
+        sg_entity_type (str): ShotGrid Entity type.
+
+    Returns:
+        sg_tags (dict[str, str]): ShotGrid Project tags dictionary
+            mapping the tag name to its id.
+    """
+    sg_tags = {
+        tags["name"].lower(): tags["id"]
+        for tags in sg_session.find("Tag", [], fields=["name", "id"])
+    }
+    logging.debug(f"ShotGrid tags: {sg_tags}")
+    return sg_tags
 
 
 def get_sg_pipeline_steps(
@@ -895,7 +918,7 @@ def get_sg_custom_attributes_data(
         if ay_attrib in ["status", "tags"]:
             attrib_value = ay_entity.get(ay_attrib)
         else:
-            attrib_value = ay_entity["attribs"].get(ay_attrib)
+            attrib_value = ay_entity.get("attribs", {}).get(ay_attrib)
         
         if attrib_value is None:
             continue

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -194,9 +194,6 @@ def create_ay_custom_attribs_in_sg_entity(
         # If it doesn't exist, we create a custom attribute on the
         # SG entity by prefixing it with "sg_"
         if not exists:
-            logging.debug(
-                f"Creating ShotGrid field for {sg_attrib} on entity {sg_entity_type}"
-            )
             get_or_create_sg_field(
                 sg_session,
                 sg_entity_type,
@@ -255,9 +252,7 @@ def create_sg_entities_in_ay(
     shotgrid_project: dict,
     sg_enabled_entities: list,
 ):
-    """Ensure AYON has all the SG Steps (to use as task types)
-
-    and Folder types.
+    """Ensure AYON has all the SG Steps (to use as task types) and Folder types.
 
     Args:
         project_entity (ProjectEntity): The ProjectEntity for a given project.
@@ -493,8 +488,6 @@ def get_sg_entities(
     sg_ay_dicts_parents: Dict[str, list] = (
         collections.defaultdict(list)
     )
-
-    logging.debug("---- Query fields %s" % query_fields)
 
     for enabled_entity in project_enabled_entities:
         entity_name, parent_field = enabled_entity
@@ -929,11 +922,11 @@ def update_ay_entity_custom_attributes(
     values_to_update: Optional[list] = None,
 ):
     """Update Ayon entity custom attributes from ShotGrid dictionary"""
-    for ay_attrib, sg_attrib in custom_attribs_map.items():
+    for ay_attrib, _ in custom_attribs_map.items():
         if values_to_update and ay_attrib not in values_to_update:
             continue
         
-        attrib_value = sg_ay_dict["attribs"].get(sg_attrib)
+        attrib_value = sg_ay_dict["attribs"].get(ay_attrib)
         if attrib_value is None:
             continue
 
@@ -941,6 +934,7 @@ def update_ay_entity_custom_attributes(
             logging.warning("Tags update is not supported yet.")
             ay_entity.tags = [tag["name"] for tag in attrib_value]
         elif ay_attrib == "status":
+            logging.warning("Status update is not supported yet.")
             ay_entity.status = attrib_value
         else:
             ay_entity.attribs.set(ay_attrib, attrib_value)

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -288,6 +288,9 @@ def create_sg_entities_in_ay(
     # Add ShotGrid Statuses to AYON Project Entity
     ay_status_codes = [s.short_name.lower() for s in list(project_entity.statuses)]
     for sg_entity_type in sg_enabled_entities:
+        if sg_entity_type == "Project":
+            # Skipping statuses from SG project as they are irrelevant in AYON
+            continue
         for status_code, status_name in get_sg_statuses(sg_session, sg_entity_type).items():
             if status_code.lower() not in ay_status_codes:
                 project_entity.statuses.create(status_name, short_name=status_code)
@@ -826,7 +829,11 @@ def get_sg_statuses(
     # NOTE: this is a limitation in Ayon as the statuses are global and not
     # per entity
     if sg_entity_type:
-        entity_status = sg_session.schema_field_read(sg_entity_type, "sg_status_list")
+        if sg_entity_type == "Project":
+            status_field = "sg_status"
+        else:
+            status_field = "sg_status_list"
+        entity_status = sg_session.schema_field_read(sg_entity_type, status_field)
         sg_statuses = entity_status["sg_status_list"]["properties"]["display_values"]["value"]
         logging.debug(f"ShotGrid Statuses supported by {sg_entity_type}: {sg_statuses}")
         return sg_statuses

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -506,7 +506,7 @@ def get_sg_entities(
 
                 if (
                     parent_field != "project"
-                    and entity[parent_field]
+                    and sg_entity[parent_field]
                     and entity_name != "Asset"
                 ):
                     parent_id = sg_entity[parent_field]["id"]
@@ -606,7 +606,6 @@ def get_sg_entity_as_ay_dict(
         sg_entity, project_code_field, custom_attribs_map
     )
 
-    # TODO: add missing sg_status_list?
     for field in extra_fields:
         sg_value = sg_entity.get(field)
         # If no value in SG entity skip

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -42,17 +42,21 @@ class ShotgridTransmitter:
                 self.settings["service_settings"]["ayon_service_user"]
 
             # Compatibility settings
-            custom_attributes_map = self.settings["compatibility_settings"][
-                "custom_attributes_map"]
-            self.custom_attributes_map = {
+            custom_attribs_map = self.settings["compatibility_settings"][
+                "custom_attribs_map"]
+            self.custom_attribs_map = {
                 attr["ayon"]: attr["sg"]
-                for attr in custom_attributes_map
+                for attr in custom_attribs_map
+                if attr["sg"]
+            }
+            self.custom_attribs_types = {
+                attr["sg"]: (attr["type"], attr["scope"])
+                for attr in custom_attribs_map
                 if attr["sg"]
             }
             self.sg_enabled_entities = (
                 self.settings["compatibility_settings"]
                              ["shotgrid_enabled_entities"])
-
             try:
                 self.sg_polling_frequency = int(
                     self.settings["service_settings"]["polling_frequency"]
@@ -77,10 +81,14 @@ class ShotgridTransmitter:
             "entity.task.renamed",
             "entity.task.create",
             "entity.task.attrib_changed",
+            "entity.task.status_changed",
+            "entity.task.tags_changed",
             "entity.folder.created",
             "entity.folder.deleted",
             "entity.folder.renamed",
             "entity.folder.attrib_changed",
+            "entity.folder.status_changed",
+            "entity.folder.tags_changed",
         ]
 
         logging.debug(
@@ -164,7 +172,8 @@ class ShotgridTransmitter:
                     self.sg_api_key,
                     self.sg_script_name,
                     sg_project_code_field=self.sg_project_code_field,
-                    custom_attributes_map=self.custom_attributes_map,
+                    custom_attribs_map=self.custom_attribs_map,
+                    custom_attribs_types=self.custom_attribs_types,
                     sg_enabled_entities=self.sg_enabled_entities,
                 )
 


### PR DESCRIPTION
## Description
This adds much better support to sync custom attributes by exposing types and scope in the settings so we can auto-populate the attributes on the entities for the user instead of having to add them manually:
![image](https://github.com/ynput/ayon-shotgrid/assets/4348536/4b7bb6eb-8928-40fd-98b5-4bb0a754c713)

It also abstracts away the "sg_" prefix on the attributes so it supports syncronization of both native and non-native SG fields as some entities have those fields as native and some others don't.

This also tackles some of the existing limitation of status/tags events not triggering, although the sync of statuses is currently only working from Ayon to SG because the Ayon API doesn't seem to update the status entity for some reason. I also fixed the status syncronization from SG to Ayon project so we aren't case sensitive.

@jakubjezek001 is there a plan to add support of defining statuses by entity instead of just a global list of entries?

## TODO:
* Make the type setting enumerator a single entry selection and not a list
* Add custom attributes during entities creation
* Fix status/tags synchronization