### PR TITLE
Remove use of SG secret to retrieve API key

### DIFF
--- a/client/ayon_shotgrid/addon.py
+++ b/client/ayon_shotgrid/addon.py
@@ -17,9 +17,8 @@ class ShotgridAddon(AYONAddon, IPluginPaths):
         addon_settings = studio_settings.get(self.name, dict())
         self._shotgrid_server_url = addon_settings.get("shotgrid_server")
 
-        sg_secret = ayon_api.get_secret(addon_settings["shotgrid_api_secret"])
-        self._shotgrid_script_name = sg_secret.get("name")
-        self._shotgrid_api_key = sg_secret.get("value")
+        self._shotgrid_script_name = addon_settings["shotgrid_api_name"]
+        self._shotgrid_api_key = addon_settings["shotgrid_api_key"]
         self._enable_local_storage = addon_settings.get("enable_shotgrid_local_storage")
         self._local_storage_key = addon_settings.get("local_storage_key")
 

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -37,11 +37,25 @@ class ShotgridSettings(BaseSettingsModel):
         description="The URL to the Shotgrid Server we want to interact with.",
         example="https://my-site.shotgrid.autodesk.com"
     )
-    shotgrid_api_secret: str = Field(
+    shotgrid_api_name: str = Field(
         default="",
-        enum_resolver=secrets_enum,
-        title="Shotgrid API Secret",
-        description="An AYON Secret where the key is the `script_name` and the value is the `api_key` from Shotgrid. See more at: https://developer.shotgridsoftware.com/python-api/authentication.html#setting-up-shotgrid"
+        title="ShotGrid API Script Name",
+        description=(
+            "The script_name that contains the API key to access ShotGrid."
+            "See more at: "
+            "https://developer.shotgridsoftware.com/python-api/authentication"
+            ".html#setting-up-shotgrid"
+        )
+    )
+    shotgrid_api_key: str = Field(
+        default="",
+        title="ShotGrid API Key",
+        description=(
+            "The API key corresponding to the Script Name to access ShotGrid."
+            "See more at: "
+            "https://developer.shotgridsoftware.com/python-api/authentication"
+            ".html#setting-up-shotgrid"
+        )
     )
     shotgrid_project_code_field: str = Field(
         default="code",

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -48,9 +48,8 @@ class ShotgridListener:
             self.sg_url = self.settings["shotgrid_server"]
             self.sg_project_code_field = self.settings["shotgrid_project_code_field"]
 
-            shotgrid_secret = ayon_api.get_secret(self.settings["shotgrid_api_secret"])
-            self.sg_script_name = shotgrid_secret.get("name")
-            self.sg_api_key = shotgrid_secret.get("value")
+            self.sg_script_name = self.settings["shotgrid_api_name"]
+            self.sg_api_key = self.settings["shotgrid_api_key"]
 
             try:
                 self.shotgrid_polling_frequency = int(

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -44,9 +44,8 @@ class ShotgridProcessor:
             self.sg_url = self.settings["shotgrid_server"]
             self.sg_project_code_field = self.settings["shotgrid_project_code_field"]
 
-            sg_secret = ayon_api.get_secret(self.settings["shotgrid_api_secret"])
-            self.sg_script_name = sg_secret.get("name")
-            self.sg_api_key = sg_secret.get("value")
+            self.sg_script_name = self.settings["shotgrid_api_name"]
+            self.sg_api_key = self.settings["shotgrid_api_key"]
 
             try:
                 self.sg_polling_frequency = int(

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -40,9 +40,8 @@ class ShotgridTransmitter:
             self.sg_url = self.settings["shotgrid_server"]
             self.sg_project_code_field = self.settings["shotgrid_project_code_field"]
 
-            sg_secret = ayon_api.get_secret(self.settings["shotgrid_api_secret"])
-            self.sg_script_name = sg_secret.get("name")
-            self.sg_api_key = sg_secret.get("value")
+            self.sg_script_name = self.settings["shotgrid_api_name"]
+            self.sg_api_key = self.settings["shotgrid_api_key"]
             self.ayon_service_user = self.settings["service_settings"]["ayon_service_user"]
 
             try:


### PR DESCRIPTION
Remove the use of the Ayon secret as non-admin users were getting an error trying to publish as reported here https://community.ynput.io/t/shotgrid-addon-secrets-permissions-and-proxy-problems/1343/7