### PR TITLE
Fix HTTPS_PROXY env var

### DIFF
--- a/client/ayon_shotgrid/addon.py
+++ b/client/ayon_shotgrid/addon.py
@@ -49,7 +49,7 @@ class ShotgridAddon(AYONAddon, IPluginPaths):
         from .lib import credentials
 
         sg_username = os.getenv("AYON_SG_USERNAME")
-        proxy = os.environ.get("HTTPS_PROXY", "").lstrip("https://")
+        proxy = os.environ.get("HTTPS_PROXY", "").replace("https://", "")
 
         return credentials.create_sg_session(
             self._shotgrid_server_url,

--- a/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_publish.py
+++ b/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_publish.py
@@ -108,7 +108,7 @@ class IntegrateShotgridPublish(pyblish.api.InstancePlugin):
                             sg_local_storage["mac_path"]
                         )
 
-                    file_partial_path = file_partial_path.lstrip("/")
+                    file_partial_path = file_partial_path.replace("/", "")
                 except ValueError as exc:
                     raise KnownPublishError(
                         f"Filepath {local_path} doesn't match the "


### PR DESCRIPTION
Replace the use of `lstrip` with `replace` to remove `https://` from proxy env as it was stripping extra characters as reported here https://community.ynput.io/t/shotgrid-addon-secrets-permissions-and-proxy-problems/1343/7