### PR TITLE
Integrating thumbnails

### DIFF
--- a/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_publish.py
+++ b/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_publish.py
@@ -1,6 +1,7 @@
 import os
 import re
 import platform
+from tkinter import N
 
 import pyblish.api
 
@@ -30,6 +31,15 @@ class IntegrateShotgridPublish(pyblish.api.InstancePlugin):
         if not sg_version:
             return
 
+        # find thumbnail path
+        thumbnail_path = instance.data.get("thumbnailPath")
+
+        if thumbnail_path:
+            sg_session.upload_thumbnail(
+                sg_version["type"], sg_version["id"], thumbnail_path
+            )
+
+        published_files = []
         for representation in instance.data.get("representations", []):
 
             if "shotgridreview" not in representation.get("tags", []):
@@ -43,42 +53,77 @@ class IntegrateShotgridPublish(pyblish.api.InstancePlugin):
                 instance, representation, False
             )
 
-            sg_project = instance.data.get("shotgridProject")
-            sg_entity = instance.data.get("shotgridEntity")
-            sg_task = instance.data.get("shotgridTask")
+            is_sequence = len(representation["files"]) > 1
 
-            code = os.path.basename(local_path)
-            # Extract and remove version number from code so Published file
-            # versions are grouped together. More info about this on:
-            # https://developer.shotgridsoftware.com/tk-core/_modules/tank/"
-            # "util/shotgun/publish_creation.html
-            version_number = 0
-            match = re.search("_v(\\d+)", code)
-            if match:
-                version_number = int(match.group(1))
-                # Remove version from name
-                code = re.sub("_v\\d+", "", code)
-                # Remove frames from name
-                #   (i.e., filename.1001.exr -> filename.exr)
-                code = re.sub("\\.\\d+", "", code)
+            self._publish_file_as_version(
+                instance, sg_session, sg_version, local_path, is_sequence
+            )
+            published_files.append(local_path)
 
-            query_filters = [
+    def _publish_file_as_version(
+            self,
+            instance,
+            sg_session,
+            sg_version,
+            local_path,
+            is_sequence=False,
+            ignore_storage=False,
+    ) -> None:
+        """Publish a file as a version in Shotgrid.
+
+        Args:
+            instance (pyblish.api.Instance): The instance to publish.
+            sg_session (shotgun_api3.Shotgun): The Shotgrid session.
+            sg_version (dict): The Shotgrid version to add the published file.
+            local_path (str): The local path of the file to publish.
+            is_sequence (bool): Whether the file is a sequence.
+            ignore_storage (bool): Whether to ignore Shotgrid Local Storage.
+        """
+        sg_session = instance.context.data.get("shotgridSession")
+        sg_version = instance.data.get("shotgridVersion")
+        sg_project = instance.data.get("shotgridProject")
+        sg_entity = instance.data.get("shotgridEntity")
+        sg_task = instance.data.get("shotgridTask")
+
+        code = os.path.basename(local_path)
+        # Extract and remove version number from code so Published file
+        # versions are grouped together. More info about this on:
+        # https://developer.shotgridsoftware.com/tk-core/_modules/tank/"
+        # "util/shotgun/publish_creation.html
+        version_number = 0
+        match = re.search("_v(\\d+)", code)
+        if match:
+            version_number = int(match.group(1))
+            # Remove version from name
+            code = re.sub("_v\\d+", "", code)
+            # Remove frames from name
+            #   (i.e., filename.1001.exr -> filename.exr)
+            code = re.sub("\\.\\d+", "", code)
+
+        query_filters = [
                 ["project", "is", sg_project],
                 ["entity", "is", sg_entity],
                 ["version", "is", sg_version],
                 ["code", "is", code],
             ]
 
-            if sg_task:
-                query_filters.append(["task", "is", sg_task])
+        if sg_task:
+            query_filters.append(["task", "is", sg_task])
 
-            sg_published_file = sg_session.find_one(
+        self.log.debug(f"Query filters: {query_filters}")
+
+        sg_published_file = sg_session.find_one(
                 "PublishedFile",
                 query_filters
             )
 
-            if instance.context.data.get("shotgridLocalStorageEnabled"):
-                sg_local_storage = sg_session.find_one(
+        self.log.debug(f"____ PublishedFile: {sg_published_file}")
+
+        if (
+            instance.context.data.get("shotgridLocalStorageEnabled")
+            and not ignore_storage
+        ):
+            sg_local_storage = sg_session.find_one(
                     "LocalStorage",
                     filters=[
                         [
@@ -90,8 +135,8 @@ class IntegrateShotgridPublish(pyblish.api.InstancePlugin):
                     fields=["mac_path", "windows_path", "linux_path"]
                 )
 
-                if not sg_local_storage:
-                    raise KnownPublishError(
+            if not sg_local_storage:
+                raise KnownPublishError(
                         "Unable to find a Local Storage in Shotgrid."
                         "Enable them in Site Preferences > Local Management:"
                         "https://help.autodesk.com/view/SGSUB/ENU/?guid="
@@ -99,27 +144,27 @@ class IntegrateShotgridPublish(pyblish.api.InstancePlugin):
                         "local_files_html"
                     )
 
-                self.log.debug(f"Using the Local Storage: {sg_local_storage}")
+            self.log.debug(f"Using the Local Storage: {sg_local_storage}")
 
-                try:
-                    if platform.system() == "Windows":
-                        _, file_partial_path = local_path.split(
+            try:
+                if platform.system() == "Windows":
+                    _, file_partial_path = local_path.split(
                             sg_local_storage["windows_path"]
                         )
-                        file_partial_path = file_partial_path.replace(
+                    file_partial_path = file_partial_path.replace(
                             "\\", "/")
-                    elif platform.system() == "Linux":
-                        _, file_partial_path = local_path.split(
+                elif platform.system() == "Linux":
+                    _, file_partial_path = local_path.split(
                             sg_local_storage["linux_path"]
                         )
-                    elif platform.system() == "Darwin":
-                        _, file_partial_path = local_path.split(
+                elif platform.system() == "Darwin":
+                    _, file_partial_path = local_path.split(
                             sg_local_storage["mac_path"]
                         )
 
-                    file_partial_path = file_partial_path.lstrip("/")
-                except ValueError as exc:
-                    raise KnownPublishError(
+                file_partial_path = file_partial_path.lstrip("/")
+            except ValueError as exc:
+                raise KnownPublishError(
                         f"Filepath {local_path} doesn't match the "
                         f"Shotgrid Local Storage {sg_local_storage}"
                         "Enable them in Site Preferences > Local Management:"
@@ -128,73 +173,87 @@ class IntegrateShotgridPublish(pyblish.api.InstancePlugin):
                         "files_html"
                     ) from exc
 
-                path = {
+            path = {
                     "local_storage": sg_local_storage,
                     "relative_path": file_partial_path
                 }
-            else:
-                self.log.info(
+        else:
+            self.log.info(
                     "Shotgrid Local Storage disabled, using local path.")
-                path = {"local_path": local_path}
+            path = {"local_path": local_path}
 
-            published_file_data = {
-                "project": sg_project,
-                "code": code,
-                "entity": sg_entity,
-                "version": sg_version,
-                "path": path,
-                # Add file type and version number fields
-                "published_file_type": self._find_published_file_type(
-                    instance, local_path, representation
-                ),
-                "version_number": version_number,
-            }
+        published_file_data = {
+            "project": sg_project,
+            "code": code,
+            "entity": sg_entity,
+            "version": sg_version,
+            "path": path,
+            # Add file type and version number fields
+            "published_file_type": self._find_published_file_type(
+                instance, local_path, is_sequence
+            ),
+            "version_number": version_number,
+        }
 
-            if sg_task:
-                published_file_data["task"] = sg_task
+        if sg_task:
+            published_file_data["task"] = sg_task
 
-            if not sg_published_file:
-                try:
-                    sg_published_file = sg_session.create(
+        if not sg_published_file:
+            self.log.debug(f"Creating Shotgrid PublishedFile: {published_file_data} ")
+            try:
+                sg_published_file = sg_session.create(
                         "PublishedFile",
                         published_file_data
                     )
-                except Exception as e:
-                    self.log.error(
+            except Exception as e:
+                self.log.error(
                         "Unable to create PublishedFile with data: "
                         f"{published_file_data}"
                     )
-                    raise e
+                raise e
 
-                self.log.info(
+            self.log.info(
                     f"Created Shotgrid PublishedFile: {sg_published_file}"
                 )
-            else:
-                sg_session.update(
+        else:
+            sg_session.update(
                     sg_published_file["type"],
                     sg_published_file["id"],
                     published_file_data,
                 )
-                self.log.info(
+            self.log.info(
                     f"Update Shotgrid PublishedFile: {sg_published_file}"
                 )
 
-            if instance.data["productType"] == "image":
-                sg_session.upload_thumbnail(
+        if instance.data["productType"] == "image":
+            sg_session.upload_thumbnail(
                     sg_published_file["version"]["type"],
                     sg_published_file["version"]["id"],
                     local_path,
                 )
-            instance.data["shotgridPublishedFile"] = sg_published_file
+        instance.data["shotgridPublishedFile"] = sg_published_file
 
-    def _find_published_file_type(self, instance, filepath, representation):
-        """Given a filepath infer what type of published file type it is."""
+    def _find_published_file_type(
+            self,
+            instance,
+            filepath,
+            is_sequence=False,
+        ) -> dict:
+        """Given a filepath infer what type of published file type it is.
+
+        Args:
+            instance (pyblish.api.Instance): The instance to publish.
+            filepath (str): The path of the file.
+            is_sequence (bool): Whether the file is a sequence.
+
+        Returns:
+            dict: The Shotgrid PublishedFileType data.
+        """
 
         _, ext = os.path.splitext(filepath)
         published_file_type = "Unknown"
 
         if ext in [".exr", ".jpg", ".jpeg", ".png", ".dpx", ".tif", ".tiff"]:
-            is_sequence = len(representation["files"]) > 1
             published_file_type = "Rendered Image" if is_sequence else "Image"
         elif ext in [".mov", ".mp4"]:
             published_file_type = "Movie"
@@ -215,12 +274,17 @@ class IntegrateShotgridPublish(pyblish.api.InstancePlugin):
 
         filters = [["code", "is", published_file_type]]
         sg_session = instance.context.data.get("shotgridSession")
+
+        # Find or create a PublishedFileType
         sg_published_file_type = sg_session.find_one(
             "PublishedFileType", filters=filters
         )
+
+        # Create PublishedFileType if it doesn't exist
         if not sg_published_file_type:
             # Create a published file type on the fly
             sg_published_file_type = sg_session.create(
                 "PublishedFileType", {"code": published_file_type}
             )
+
         return sg_published_file_type

--- a/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_version.py
+++ b/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_version.py
@@ -40,6 +40,10 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
         if intent:
             data_to_update["sg_status_list"] = intent["value"]
 
+        # find thumbnail path
+        thumbnail_path = instance.data.get("thumbnailPath")
+
+        found_reviewable = False
         for representation in instance.data.get("representations", []):
             self.log.debug(pformat(representation))
 
@@ -51,6 +55,7 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
             )
 
             if f".{representation['ext']}" in VIDEO_EXTENSIONS:
+                found_reviewable = True
                 data_to_update["sg_path_to_movie"] = local_path
                 if (
                     "slate" in instance.data["families"]
@@ -59,6 +64,7 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
                     data_to_update["sg_movie_has_slate"] = True
 
             elif f".{representation['ext']}" in IMAGE_EXTENSIONS:
+                found_reviewable = True
                 # Replace the frame number with '%04d'
                 path_to_frame = re.sub(r"\.\d+\.", ".%04d.", local_path)
 
@@ -66,8 +72,14 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
                 if "slate" in instance.data["families"]:
                     data_to_update["sg_frames_have_slate"] = True
 
+        if not found_reviewable or thumbnail_path is not None:
+            # create a thumbnail data to update
+            found_reviewable = True
+            data_to_update["sg_path_to_frames"] = thumbnail_path
+
+
         # If there's no data to set/update, skip creation of SG version
-        if not data_to_update:
+        if not found_reviewable:
             self.log.info(
                 "No data to integrate to SG for product name "
                 f"'{instance.data['productName']}', skipping "
@@ -164,6 +176,7 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
         sg_session.update("Version", sg_version["id"], data_to_update)
 
         instance.data["shotgridVersion"] = sg_version
+        self.log.debug(f"Shotgrid version: {sg_version}")
 
     def _find_existing_version(self, version_name, instance):
         """Find if a Version already exists in ShotGrid.

--- a/service_tools/example_env
+++ b/service_tools/example_env
@@ -1,2 +1,3 @@
 AYON_SERVER_URL=http://10.0.0.60:5000
 AYON_API_KEY=aabbccddeeffgghhiijjzzyyxx112233
+LOGLEVEL=DEBUG

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -20,7 +20,6 @@ from ayon_api import get_attributes_for_type
 import shotgun_api3
 
 
-
 _loggers = {}
 
 


### PR DESCRIPTION
Thumbnails now come from the thumbnailPath in the instance data. This solves the issue when video or image sequences aren't published, but a thumbnail is still there.