### PR TITLE
Fixing service transmitter failing synchronization

### DIFF
--- a/client/ayon_shotgrid/version.py
+++ b/client/ayon_shotgrid/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring shotgrid addon version."""
-__version__ = "0.4.2-dev.2"
+__version__ = "0.4.2-dev.3"

--- a/frontend/dist/shotgrid-addon.js
+++ b/frontend/dist/shotgrid-addon.js
@@ -213,7 +213,7 @@ const getAyonProjects = async () => {
 
 
 const syncShotgridToAyon = async (projectName, projectCode) => {
-  /* Spawn an AYON Event of topic "shotgrid.event" to synchcronize a project
+  /* Spawn an AYON Event of topic "shotgrid.event" to synchronize a project
   from Shotgrid into AYON. */
   call_result_paragraph = document.getElementById("call-result");
 
@@ -239,12 +239,12 @@ const syncShotgridToAyon = async (projectName, projectCode) => {
     });
 
   if (dispatch_event) {
-    call_result_paragraph.innerHTML = `Succesfully Spawned Event! ${dispatch_event.data.id}`
+    call_result_paragraph.innerHTML = `Successfully Spawned Event! ${dispatch_event.data.id} Make sure there's a processor <a target="_parent" href="/services">Service running</a>`
   }
 }
 
 const syncAyonToShotgrid = async (projectName, projectCode) => {
-  /* Spawn an AYON Event of topic "shotgrid.event" to synchcronize a project
+  /* Spawn an AYON Event of topic "shotgrid.event" to synchronize a project
   from AYON into Shotgrid. */
   call_result_paragraph = document.getElementById("call-result");
 
@@ -270,7 +270,7 @@ const syncAyonToShotgrid = async (projectName, projectCode) => {
     });
 
   if (dispatch_event) {
-    call_result_paragraph.innerHTML = `Succesfully Spawned Event! ${dispatch_event.data.id} Make sure there's a processor <a target="_parent" href="/services">Service running</a>`
+    call_result_paragraph.innerHTML = `Successfully Spawned Event! ${dispatch_event.data.id} Make sure there's a processor <a target="_parent" href="/services">Service running</a>`
   }
 }
 

--- a/package.py
+++ b/package.py
@@ -1,6 +1,6 @@
 name = "shotgrid"
 title = "Shotgrid"
-version = "0.4.2-dev.2"
+version = "0.4.2-dev.3"
 client_dir = "ayon_shotgrid"
 
 services = {

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -182,9 +182,9 @@ class ShotgridListener:
         last_event_id = None
 
         while True:
-            base_sg_filters = self._build_shotgrid_filters()
+            sg_filters = self._build_shotgrid_filters()
 
-            if not base_sg_filters:
+            if not sg_filters:
                 self.log.debug(
                     f"Leecher waiting {self.shotgrid_polling_frequency} "
                     "seconds. No projects with AYON Auto Sync found."

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -222,7 +222,7 @@ class ShotgridListener:
                     limit=50,
                 )
 
-                self.log.info(f"Found {len(events)} events in Shotgrid.")
+                self.log.debug(f"Found {len(events)} events in Shotgrid.")
 
                 sg_projects_by_id = {
                     sg_project["id"]: sg_project

--- a/services/leecher/pyproject.toml
+++ b/services/leecher/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 
 [tool.poetry.dependencies]
 appdirs = "^1.4"
-python = ">=3.9,<4.0"
+python = ">=3.10,<4.0"
 pydantic = "^1.10.2"
 ayon-python-api = "^1.0.0"
 shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }

--- a/services/leecher/pyproject.toml
+++ b/services/leecher/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shotgrid-leecher"
-version = "0.4.2-dev.2"
+version = "0.4.2-dev.3"
 description = "Shotgrid Integration for Ayon"
 authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 

--- a/services/processor/processor/handlers/sync_projects.py
+++ b/services/processor/processor/handlers/sync_projects.py
@@ -13,9 +13,9 @@ def process_event(
 ):
     """Synchronize a project between AYON and Shotgrid.
 
-    Events with the action `sync-from-shotgrid` or `sync-from-ayon` will trigger
-    this function, where we travees a whole project, either in Shotgrid or AYON,
-    and replciate it's structe in the other platform.
+    Events with the action `sync-from-shotgrid` or `sync-from-ayon` will
+    trigger this function, where we traverse a whole project, either in
+    Shotgrid or AYON, and replicate it's structure in the other platform.
     """
     hub = AyonShotgridHub(
         kwargs.get("project_name"),
@@ -31,6 +31,7 @@ def process_event(
 
     # This will ensure that the project exists in both platforms.
     hub.create_project()
-    hub.synchronize_projects(
-        source="ayon" if kwargs.get("action") == "sync-from-ayon" else "shotgrid"
+    sync_source = (
+        "ayon" if kwargs.get("action") == "sync-from-ayon" else "shotgrid"
     )
+    hub.synchronize_projects(source=sync_source)

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -176,12 +176,12 @@ class ShotgridProcessor:
                     continue
 
                 for handler in self.handlers_map.get(payload["action"], []):
-                    # If theres any handler "subscirbed" to this event type..
+                    # If theres any handler "subscribed" to this event type..
                     try:
                         self.log.info(f"Running the Handler {handler}")
                         ayon_api.update_event(
                             event["id"],
-                            description=f"Procesing event with Handler {payload['action']}...",
+                            description=f"Processing event with Handler {payload['action']}...",
                             status="finished"
                         )
                         handler.process_event(
@@ -189,7 +189,7 @@ class ShotgridProcessor:
                             **payload,
                         )
 
-                    except Exception as e:
+                    except Exception:
                         self.log.error(
                             f"Unable to process handler {handler.__name__}",
                             exc_info=True
@@ -197,12 +197,19 @@ class ShotgridProcessor:
                         ayon_api.update_event(
                             event["id"],
                             status="failed",
-                            description=f"An error ocurred while processing the Event: {e}",
+                            description="An error ocurred while processing",
+                            payload={
+                                "message": traceback.format_exc(),
+                            },
                         )
                         ayon_api.update_event(
                             source_event["id"],
                             status="failed",
-                            description=f"The service `processor` was unable to process this event. Check the `shotgrid.proc` <{event['id']}> event for more info."
+                            description=(
+                                "The service `processor` was unable to "
+                                "process this event. Check the `shotgrid.proc`"
+                                f" <{event['id']}> event for more info."
+                            )
                         )
 
                 self.log.info("Event has been processed... setting to finished!")

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -145,8 +145,8 @@ class ShotgridProcessor:
         `REGISTER_EVENT_TYPE` attribute.
 
         For example, an event that has `{"action": "create-project"}` payload,
-        will trigger the `handlers/project_sync.py` since that one has the attribute
-        REGISTER_EVENT_TYPE = ["create-project"]
+        will trigger the `handlers/project_sync.py` since that one has the
+        attribute REGISTER_EVENT_TYPE = ["create-project"]
         """
         while True:
             try:
@@ -162,17 +162,22 @@ class ShotgridProcessor:
                     time.sleep(self.sg_polling_frequency)
                     continue
 
+                # Get source event because it is having payload to process
                 source_event = ayon_api.get_event(event["dependsOn"])
                 payload = source_event["payload"]
 
                 if not payload:
-                    time.sleep(self.sg_polling_frequency)
                     ayon_api.update_event(
                         event["id"],
-                        description=f"Unable to process the event <{source_event['id']}> since it has no Shotgrid Payload!",
+                        description=(
+                            "Unable to process the event "
+                            f"<{source_event['id']}> since it has no "
+                            "Shotgrid Payload!"
+                        ),
                         status="finished"
                     )
-                    ayon_api.update_event(source_event["id"], status="finished")
+                    ayon_api.update_event(
+                        source_event["id"], status="finished")
                     continue
 
                 for handler in self.handlers_map.get(payload["action"], []):
@@ -181,7 +186,10 @@ class ShotgridProcessor:
                         self.log.info(f"Running the Handler {handler}")
                         ayon_api.update_event(
                             event["id"],
-                            description=f"Processing event with Handler {payload['action']}...",
+                            description=(
+                                "Processing event with Handler "
+                                f"{payload['action']}..."
+                            ),
                             status="finished"
                         )
                         handler.process_event(
@@ -212,7 +220,8 @@ class ShotgridProcessor:
                             )
                         )
 
-                self.log.info("Event has been processed... setting to finished!")
+                self.log.info(
+                    "Event has been processed... setting to finished!")
                 ayon_api.update_event(
                     event["id"],
                     description="Event processed successfully.",
@@ -222,8 +231,3 @@ class ShotgridProcessor:
 
             except Exception:
                 self.log.error(traceback.format_exc())
-
-            self.log.info(
-                f"Waiting {self.sg_polling_frequency} seconds..."
-            )
-            time.sleep(self.sg_polling_frequency)

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shotgrid-processor"
-version = "0.4.2-dev.2"
+version = "0.4.2-dev.3"
 description = "Shotgrid Integration for Ayon"
 authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 
 [tool.poetry.dependencies]
 appdirs = "^1.4"
-python = ">=3.9,<4.0"
+python = ">=3.10,<4.0"
 pydantic = "^1.10.2"
 ayon-python-api = "^1.0.0"
 shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -415,7 +415,6 @@ class AyonShotgridHub:
                 remove_sg_entity_from_ayon_event(
                     ayon_event,
                     self._sg,
-                    self._ay_project,
                 )
 
             case "entity.task.renamed" | "entity.folder.renamed":

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -144,7 +144,11 @@ def match_ayon_hierarchy_in_shotgrid(
                 )
                 sg_entity_id = sg_ay_dict["attribs"][SHOTGRID_ID_ATTRIB]
                 sg_ay_dicts[sg_entity_id] = sg_ay_dict
-                sg_ay_dicts_parents[sg_parent_entity["id"]].append(sg_ay_dict)
+
+                # Add the new entity id to the parent's children
+                # this is important for making sure no duplicity is created
+                sg_id = sg_ay_dict["attribs"][SHOTGRID_ID_ATTRIB]
+                sg_ay_dicts_parents[sg_parent_entity["id"]].add(sg_id)
 
             ay_entity.attribs.set(
                 SHOTGRID_ID_ATTRIB,

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -1,4 +1,12 @@
 import collections
+import shotgun_api3
+from typing import Dict, List, Union
+
+import ayon_api
+from ayon_api.entity_hub import (
+    ProjectEntity,
+    FolderEntity,
+)
 
 from ayon_api import slugify_string
 
@@ -22,12 +30,12 @@ log = get_logger(__file__)
 
 
 def match_shotgrid_hierarchy_in_ayon(
-    entity_hub,
-    sg_project,
-    sg_session,
-    sg_enabled_entities,
-    project_code_field,
-    custom_attribs_map,
+    entity_hub: ayon_api.entity_hub.EntityHub,
+    sg_project: Dict,
+    sg_session: shotgun_api3.Shotgun,
+    sg_enabled_entities: List[str],
+    project_code_field: str,
+    custom_attribs_map: Dict[str, str]
 ):
     """Replicate a Shotgrid project into AYON.
 
@@ -213,7 +221,11 @@ def match_shotgrid_hierarchy_in_ayon(
     )
 
 
-def _create_new_entity(entity_hub, parent_entity, sg_ay_dict):
+def _create_new_entity(
+    entity_hub: ayon_api.entity_hub.EntityHub,
+    parent_entity: Union[ProjectEntity, FolderEntity],
+    sg_ay_dict: Dict
+):
     """Helper method to create entities in the EntityHub.
 
     Task Creation:

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -73,10 +73,6 @@ def match_shotgrid_hierarchy_in_ayon(
                 f"Ay Parent Entity: {ay_parent_entity}"
             )
             log.warning(msg)
-
-            # append msg to temp file for debugging
-            with open("/service/processed_ids.txt", "a") as f:
-                f.write(f"{msg}\n")
             continue
 
         processed_ids.add(sg_entity_id)

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -331,10 +331,24 @@ def remove_ayon_entity_from_sg_event(
     )
 
     if not sg_ay_dict:
-        raise ValueError(
-            f"Entity {sg_event['entity_type']} <{sg_event['entity_id']}> "
-            "no longer exists in ShotGrid."
+        sg_ay_dict = get_sg_entity_as_ay_dict(
+            sg_session,
+            sg_event["entity_type"],
+            sg_event["entity_id"],
+            project_code_field,
+            retired_only=False,
         )
+        if sg_ay_dict:
+            log.info(
+                f"No need to remove entity {sg_event['entity_type']} "
+                f"<{sg_event['entity_id']}>, it's not retired anymore."
+            )
+            return
+        else:
+            log.warning(
+                f"Entity {sg_event['entity_type']} <{sg_event['entity_id']}> "
+                "no longer exists in ShotGrid."
+            )
 
     if not sg_ay_dict["data"].get(CUST_FIELD_CODE_ID):
         raise ValueError("ShotGrid Missing Ayon ID")

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -25,7 +25,7 @@ And most of the times it fetches the ShotGrid entity as an Ayon dict like:
 """
 import shotgun_api3
 import ayon_api
-from typing import Dict, List, Union, Optional
+from typing import Dict, List, Optional
 
 from utils import (
     get_asset_category,

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -23,6 +23,9 @@ And most of the times it fetches the ShotGrid entity as an Ayon dict like:
 }
 
 """
+import shotgun_api3
+import ayon_api
+from typing import Dict, List, Union, Optional
 
 from utils import (
     get_asset_category,
@@ -44,13 +47,13 @@ log = get_logger(__file__)
 
 
 def create_ay_entity_from_sg_event(
-    sg_event,
-    sg_project,
-    sg_session,
-    ayon_entity_hub,
-    sg_enabled_entities,
-    project_code_field,
-    custom_attribs_map=None,
+    sg_event: Dict,
+    sg_project: Dict,
+    sg_session: shotgun_api3.Shotgun,
+    ayon_entity_hub: ayon_api.entity_hub.EntityHub,
+    sg_enabled_entities: List[str],
+    project_code_field: str,
+    custom_attribs_map: Optional[Dict[str, str]] = None
 ):
     """Create an AYON entity from a ShotGrid Event.
 
@@ -61,8 +64,8 @@ def create_ay_entity_from_sg_event(
         ayon_entity_hub (ayon_api.entity_hub.EntityHub): The AYON EntityHub.
         sg_enabled_entities (list[str]): List of entity strings enabled.
         project_code_field (str): The Shotgrid project code field.
-        custom_attribs_map (dict): Dictionary that maps a list of attribute
-            names from AYON to Shotgrid.
+        custom_attribs_map (Optional[dict]): A dictionary that maps ShotGrid
+            attributes to Ayon attributes.
 
     Returns:
         ay_entity (ayon_api.entity_hub.EntityHub.Entity): The newly
@@ -217,13 +220,13 @@ def create_ay_entity_from_sg_event(
 
 
 def update_ayon_entity_from_sg_event(
-    sg_event,
-    sg_project,
-    sg_session,
-    ayon_entity_hub,
-    sg_enabled_entities,
-    project_code_field,
-    custom_attribs_map,
+    sg_event: Dict,
+    sg_project: Dict,
+    sg_session: shotgun_api3.Shotgun,
+    ayon_entity_hub: ayon_api.entity_hub.EntityHub,
+    sg_enabled_entities: List[str],
+    project_code_field: str,
+    custom_attribs_map: Optional[Dict[str, str]] = None
 ):
     """Try to update an entity in Ayon.
 
@@ -309,10 +312,10 @@ def update_ayon_entity_from_sg_event(
 
 
 def remove_ayon_entity_from_sg_event(
-    sg_event,
-    sg_session,
-    ayon_entity_hub,
-    project_code_field
+    sg_event: Dict,
+    sg_session: shotgun_api3.Shotgun,
+    ayon_entity_hub: ayon_api.entity_hub.EntityHub,
+    project_code_field: str,
 ):
     """Try to remove an entity in Ayon.
 
@@ -351,7 +354,10 @@ def remove_ayon_entity_from_sg_event(
             )
 
     if not sg_ay_dict["data"].get(CUST_FIELD_CODE_ID):
-        raise ValueError("ShotGrid Missing Ayon ID")
+        log.warning(
+            "Entity does not have an Ayon ID, aborting..."
+        )
+        return
 
     ay_entity = ayon_entity_hub.get_or_query_entity_by_id(
         sg_ay_dict["data"].get(CUST_FIELD_CODE_ID),

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -252,6 +252,13 @@ def update_ayon_entity_from_sg_event(
         custom_attribs_map=custom_attribs_map
     )
 
+    if not sg_ay_dict:
+        log.warning(
+            f"Entity {sg_event['entity_type']} <{sg_event['entity_id']}> "
+            "no longer exists in ShotGrid, aborting..."
+        )
+        return
+
     # if the entity does not have an Ayon ID, try to create it
     # and no need to update
     if not sg_ay_dict["data"].get(CUST_FIELD_CODE_ID):
@@ -325,6 +332,12 @@ def remove_ayon_entity_from_sg_event(
         ayon_entity_hub (ayon_api.entity_hub.EntityHub): The AYON EntityHub.
         project_code_field (str): The ShotGrid field that contains the Ayon ID.
     """
+    # for now we are ignoring Task type entities
+    # TODO: Handle Task entities
+    if sg_event["entity_type"] == "Task":
+        log.info("Ignoring Task entity.")
+        return
+
     sg_ay_dict = get_sg_entity_as_ay_dict(
         sg_session,
         sg_event["entity_type"],

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1,7 +1,7 @@
 import os
 import logging
 import collections
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from constants import (
     AYON_SHOTGRID_ATTRIBUTES_MAP,
@@ -13,7 +13,11 @@ from constants import (
     SHOTGRID_TYPE_ATTRIB,
 )
 
-from ayon_api.entity_hub import ProjectEntity
+from ayon_api.entity_hub import (
+    ProjectEntity,
+    TaskEntity,
+    FolderEntity,
+)
 from ayon_api.utils import slugify_string
 from ayon_api import get_attributes_for_type
 
@@ -666,7 +670,7 @@ def get_sg_entity_as_ay_dict(
     sg_type: str,
     sg_id: int,
     project_code_field: str,
-    custom_attribs_map: Optional[dict] = None,
+    custom_attribs_map: Optional[Dict[str, str]] = None,
     extra_fields: Optional[list] = None,
     retired_only: Optional[bool] = False,
 ) -> dict:
@@ -677,8 +681,8 @@ def get_sg_entity_as_ay_dict(
         sg_type (str): The ShotGrid entity type.
         sg_id (int): ShotGrid ID of the entity to query.
         project_code_field (str): The ShotGrid project code field.
-        custom_attribs_map (dict): Dictionary that maps names of attributes in
-            AYON to ShotGrid equivalents.
+        custom_attribs_map (Optional[dict]): Dictionary that maps names of
+            attributes in AYON to ShotGrid equivalents.
         extra_fields (Optional[list]): List of optional fields to query.
         retired_only (bool): Whether to return only retired entities.
     Returns:
@@ -1046,7 +1050,7 @@ def get_sg_custom_attributes_data(
 
 
 def update_ay_entity_custom_attributes(
-    ay_entity: dict,
+    ay_entity: Union[ProjectEntity, FolderEntity, TaskEntity],
     sg_ay_dict: dict,
     custom_attribs_map: dict,
     values_to_update: Optional[list] = None,

--- a/services/transmitter/pyproject.toml
+++ b/services/transmitter/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shotgrid-transmitter"
-version = "0.4.2-dev.2"
+version = "0.4.2-dev.3"
 description = "Shotgrid Integration for Ayon"
 authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 

--- a/services/transmitter/pyproject.toml
+++ b/services/transmitter/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 
 [tool.poetry.dependencies]
 appdirs = "^1.4"
-python = ">=3.9,<4.0"
+python = ">=3.10,<4.0"
 pydantic = "^1.10.2"
 ayon-python-api = "^1.0.0"
 shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -7,6 +7,7 @@ two are `created`, `renamed` or `deleted`.
 """
 import time
 import socket
+import traceback
 
 import ayon_api
 
@@ -212,7 +213,10 @@ class ShotgridTransmitter:
                 ayon_api.update_event(
                     event["id"],
                     project_name=project_name,
-                    status="failed"
+                    status="failed",
+                    payload={
+                        "message": traceback.format_exc(),
+                    },
                 )
 
             time.sleep(self.sg_polling_frequency)


### PR DESCRIPTION
## Solving following bug:
- **Service Transmitter**: 
	- creation of Asset in AYON was resolving in duplicity of Asset entities on ShotGrid server
	- Assets are now correctly typed in ShotGrid and inherits AssetCategory name from AYON

- **Service Processor**: 
	- Synchronization of project from AYON to ShotGrid was causing duplicating of Assets 
	- Assets are now correctly typed in ShotGrid and inherits AssetCategory name from AYON

## Aditional notes:
- workflow is currently locked on parent folder for assets to be AssetCategory folder type. The name of the parent is then used for defining `sg_asset_type` entity field.
- methods in Shotgrid common module were type annotated
- some typos were fixed but not all of it (there is still a log to be fixed) 
- version was bumped to `0.4.2-dev.3`

currently the PR is based on latest changes form https://github.com/ynput/ayon-shotgrid/pull/99

closes https://github.com/ynput/ayon-shotgrid/issues/98
closes https://github.com/ynput/ayon-shotgrid/issues/90