### PR TITLE
Remove project code field being disabled on settings

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -218,13 +218,13 @@ class ShotgridSettings(BaseSettingsModel):
     shotgrid_project_code_field: str = SettingsField(
         default="code",
         title="ShotGrid Project Code field name",
-        disabled=True,
         description=(
             "In order to create AYON projects, we need a Project Code, you "
             "can specify here which field in the ShotGrid Project "
             "entity represents it."
         ),
-        example="sg_code"
+        example="sg_code",
+        scope=["studio"],
     )
     enable_shotgrid_local_storage: bool = SettingsField(
         default=True,


### PR DESCRIPTION
### Changes

Makes the project code an editable field again in studio settings: `shotgrid_project_code_field`.
The default value is `code`

This setting then defines which field in the connected Shotgrid instance defines the project code to be synced.

### Additional info

This was reverted/removed in a recent PR https://github.com/ynput/ayon-shotgrid/pull/72 but being able to change the field that represents the project code on the Shotgrid instance is important because not all studios ShotGrid have `code` as the field used for setting the `id` as shown in this image of our Shotgrid:
![image](https://github.com/user-attachments/assets/e72a2a0a-cedf-471a-bd8c-8fe21b5bd300)

If we aren't able to edit the project code field to `sg_code`, our syncs can't work.

### Testing notes

**Caveats**

Someone editing the setting to something else can break their syncs as the projects won't be found. However, similar to other settings in any other addon, a change implicates something.