### PR TITLE
Fix proxy in session

### DIFF
--- a/client/ayon_shotgrid/addon.py
+++ b/client/ayon_shotgrid/addon.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from ayon_core.addon import (
     AYONAddon,
@@ -85,7 +86,7 @@ class ShotgridAddon(AYONAddon, ITrayAddon, IPluginPaths):
             "shotgrid_url": self._shotgrid_server_url,
         }
 
-        proxy = os.environ.get("HTTPS_PROXY", "").replace("https://", "")
+        proxy = re.sub(r"https?://", "", os.environ.get("HTTPS_PROXY", ""))
         if proxy:
             kwargs["proxy"] = proxy
 

--- a/client/ayon_shotgrid/lib/credentials.py
+++ b/client/ayon_shotgrid/lib/credentials.py
@@ -112,7 +112,7 @@ def create_sg_session(
             "login": username,
         })
     if proxy:
-        kwargs["proxy"] = proxy
+        kwargs["http_proxy"] = proxy
 
     session = shotgun_api3.Shotgun(**kwargs)
 


### PR DESCRIPTION
Pass the right kwarg to shotgun session for proxy and use `re.sub` instead of string replacement as string replacement replaces any of the existing chars.