### PR TITLE
AY-7217_Add support to sync task assignees and statuses for all entities

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -2,7 +2,6 @@ from typing import Any, Type, Optional
 from nxtools import logging
 from fastapi import Path
 
-from ayon_server.entities import UserEntity
 from ayon_server.addons import BaseServerAddon
 from ayon_server.lib.postgres import Postgres
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Type
+from typing import Any, Type, Optional
 from nxtools import logging
 from fastapi import Path
 
@@ -22,8 +22,8 @@ class ShotgridAddon(BaseServerAddon):
 
         # returning user for SG id value
         self.add_endpoint(
-            "/get_user_by_sg_id/{sg_user_id}",
-            self.get_user_by_sg_id,
+            "/get_ayon_name_by_sg_id/{sg_user_id}",
+            self.get_ayon_name_by_sg_id,
             method="GET",
         )
 
@@ -122,14 +122,14 @@ class ShotgridAddon(BaseServerAddon):
             logging.debug("Shotgrid Attributes already exist.")
             return False
 
-    async def get_user_by_sg_id(
+    async def get_ayon_name_by_sg_id(
         self,
         sg_user_id: str = Path(
             ...,
             description="Id of Shotgrid user ",
             example="123",
         )
-    ) -> UserEntity.model.main_model | None:
+    ) -> Optional[str]:
         """Queries user for specific 'sg_user_id' field in 'data'.
 
         Field added during user synchronization to be explicit, not depending that
@@ -143,7 +143,5 @@ class ShotgridAddon(BaseServerAddon):
         """
 
         res = await Postgres.fetch(query)
-        if not res:
-            return None
-        user = await UserEntity.load(res[0]["name"])
-        return user.payload
+        if res:
+            return res[0]["name"]

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -76,10 +76,10 @@ class ShotgridListener:
             }
             self.custom_sg_attribs = set(self.custom_attribs_map.values())
 
-            # TODO: implement a way to handle status_list and tags
             self.custom_attribs_map.update({
-                # "status": "status_list",
-                "tags": "tags"
+                "status": "status_list",
+                "tags": "tags",
+                "assignees": "task_assignees"
             })
 
             self.sg_enabled_entities = self.settings["compatibility_settings"]["shotgrid_enabled_entities"]  # noqa: E501

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -91,6 +91,12 @@ class ShotgridProcessor:
                 for attr in self.settings["compatibility_settings"]["custom_attribs_map"]
                 if attr["sg"]
             }
+            self.custom_attribs_map.update({
+                "status": "status_list",
+                "tags": "tags",
+                "assignees": "task_assignees"
+            })
+
             self.custom_attribs_types = {
                 attr["sg"]: (attr["type"], attr["scope"])
                 for attr in self.settings["compatibility_settings"]["custom_attribs_map"]

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -433,7 +433,13 @@ class AyonShotgridHub:
                     self._ay_project,
                     self.custom_attribs_map,
                 )
-            case "entity.task.status_changed" | "entity.folder.status_changed" | "entity.task.tags_changed" | "entity.folder.tags_changed":
+            case (
+                "entity.task.status_changed" |
+                "entity.folder.status_changed" |
+                "entity.task.tags_changed" |
+                "entity.folder.tags_changed" |
+                "entity.task.assignees_changed"
+            ):
                 # TODO: for some reason the payload here is not a dict but we know
                 # we always want to update the entity
                 update_sg_entity_from_ayon_event(

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -70,7 +70,8 @@ class AyonShotgridHub:
     log = get_logger(__file__)
     custom_attribs_map = {
         "status": "status_list",
-        "tags": "tags"
+        "tags": "tags",
+        "assignees": "task_assignees"
     }
 
     def __init__(self,
@@ -395,6 +396,7 @@ class AyonShotgridHub:
                     ayon_event,
                     self._sg,
                     self._ay_project,
+                    self.custom_attribs_map,
                 )
             case "entity.task.attrib_changed" | "entity.folder.attrib_changed":
                 attrib_key = next(iter(ayon_event["payload"]["newValue"]))

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -437,11 +437,11 @@ class AyonShotgridHub:
                     self.custom_attribs_map,
                 )
             case (
-                "entity.task.status_changed" |
-                "entity.folder.status_changed" |
-                "entity.task.tags_changed" |
-                "entity.folder.tags_changed" |
-                "entity.task.assignees_changed"
+                "entity.task.status_changed"
+                | "entity.folder.status_changed"
+                | "entity.task.tags_changed"
+                | "entity.folder.tags_changed"
+                | "entity.task.assignees_changed"
             ):
                 # TODO: for some reason the payload here is not a dict but we know
                 # we always want to update the entity

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -192,7 +192,9 @@ def match_ayon_hierarchy_in_shotgrid(
                 )
 
         # entity was not synced before and need to be created
-        if not sg_entity_id or not sg_ay_dict:
+        # We only create new entities for Folders/Tasks entities
+        # For Version entities we only try update the status if it already exists
+        if sg_entity_type != "Version" and (not sg_entity_id or not sg_ay_dict):
             sg_parent_entity = sg_session.find_one(
                 sg_ay_parent_entity["attribs"][SHOTGRID_TYPE_ATTRIB],
                 filters=[[
@@ -213,6 +215,10 @@ def match_ayon_hierarchy_in_shotgrid(
             sg_entity_id = sg_ay_dict["attribs"][SHOTGRID_ID_ATTRIB]
             sg_ay_dicts[sg_entity_id] = sg_ay_dict
             sg_ay_dicts_parents[sg_parent_entity["id"]].add(sg_entity_id)
+
+        if not sg_ay_dict:
+            log.warning(f"AYON entity {ay_entity} not found in SG, ignoring it")
+            continue
 
         # add Shotgrid ID and type to AYON entity
         ay_entity.attribs.set(

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
@@ -386,6 +386,7 @@ def _create_sg_entity(
             or ay_entity.entity_type != "task"
             and ay_entity.folder_type == "AssetCategory"
     ):
+        # TODO: why not??
         # AssetCategory should not be created in Shotgrid
         # task should not be child of AssetCategory
         return
@@ -410,7 +411,7 @@ def _create_sg_entity(
             sg_field_name: ay_entity.name,
             CUST_FIELD_CODE_ID: ay_entity.id,
         }
-    else:
+    elif ay_entity.entity_type == "folder":
         data = {
             "project": sg_project,
             parent_field: {
@@ -421,6 +422,9 @@ def _create_sg_entity(
             CUST_FIELD_CODE_ID: ay_entity.id,
         }
 
+    if not data:
+        return
+    
     # Fill up data with any extra attributes from Ayon we want to sync to SG
     data.update(get_sg_custom_attributes_data(
         sg_session,

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
@@ -386,7 +386,6 @@ def _create_sg_entity(
             or ay_entity.entity_type != "task"
             and ay_entity.folder_type == "AssetCategory"
     ):
-        # TODO: why not??
         # AssetCategory should not be created in Shotgrid
         # task should not be child of AssetCategory
         return

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
@@ -213,7 +213,18 @@ def update_sg_entity_from_ayon_event(
                 new_attribs["tags"].append(
                     {"name": tag_name, "id": tag_id, "type": "Tag"}
                 )
-
+        elif ayon_event["topic"].endswith("assignees_changed"):
+            sg_assignees = []
+            for user_name in new_attribs:
+                ayon_user = ayon_api.get_user(user_name)
+                if not ayon_user or not ayon_user["data"].get("sg_user_id"):
+                    log.warning(f"User {user_name} is not synched to SG yet.")
+                    continue
+                sg_assignees.append(
+                    {"type": "HumanUser",
+                     "id": ayon_user["data"]["sg_user_id"]}
+                )
+            new_attribs = {"assignees": sg_assignees}
         else:
             log.warning(
                 "Unknown event type, skipping update of custom attribs.")

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -428,7 +428,7 @@ def update_ayon_entity_from_sg_event(
                 CUST_FIELD_CODE_ID: ay_entity.id
             }
         )
-    
+
     ay_entity.attribs.set(
         SHOTGRID_ID_ATTRIB,
         sg_ay_dict["attribs"].get(SHOTGRID_ID_ATTRIB, "")

--- a/services/shotgrid_common/constants.py
+++ b/services/shotgrid_common/constants.py
@@ -129,6 +129,7 @@ SG_COMMON_ENTITY_FIELDS = [
     "content",
     "entity",
     "step",
+    "task_assignees",
     CUST_FIELD_CODE_ID,
     CUST_FIELD_CODE_SYNC,
 ]

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1338,9 +1338,17 @@ def update_ay_entity_custom_attributes(
             # not the `short_name` (which is what we get from SG) so we convert
             # the short name back to the long name before setting it
             status_mapping = {
-                status.short_name: status.name for status in ay_project.statuses
+                status.short_name: status
+                for status in ay_project.statuses
             }
-            new_status_name = status_mapping.get(attrib_value)
+            new_status = status_mapping.get(attrib_value)
+            if ay_entity.entity_type in new_status.scope:
+                ay_entity.status = new_status.name
+            else:
+                logging.warning(
+                    f"Status '{attrb_value}' not available"
+                    f" for {entity.entity_type}."
+                )
             try:
                 ay_entity.status = new_status_name
             except ValueError as e:

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -117,7 +117,7 @@ def _sg_to_ay_dict(
     ay_entity_type = "folder"
     task_type = None
     folder_type = None
-    exception_attribs = {"status", "assignees", "tags"}
+    root_level_attributes = {"status", "assignees", "tags"}
 
     if sg_entity["type"] == "Task":
         ay_entity_type = "task"
@@ -186,7 +186,7 @@ def _sg_to_ay_dict(
             if sg_value is None:
                 continue
 
-            if ay_attrib in exception_attribs:
+            if ay_attrib in root_level_attributes:
                 sg_ay_dict[ay_attrib] = sg_value
             else:
                 sg_ay_dict["attribs"][ay_attrib] = sg_value

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -173,7 +173,8 @@ def _sg_to_ay_dict(
 
     if custom_attribs_map:
         for ay_attrib, sg_attrib in custom_attribs_map.items():
-            sg_value = sg_entity.get(sg_attrib) or sg_entity.get(f"sg_{sg_attrib}")
+            sg_value = (sg_entity.get(f"sg_{sg_attrib}")
+                        or sg_entity.get(sg_attrib))
 
             # If no value in SG entity skip
             if sg_value is None:

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1436,11 +1436,7 @@ def create_new_ayon_entity(
 
     assignees = sg_ay_dict.get("assignees")
     if assignees:
-        try:
-            # INFO: it was causing error so trying to set status directly
-            ay_entity.assignees = assignees
-        except ValueError as e:
-            log.warning(f"Assignees sync not implemented: {e}")
+        ay_entity.assignees = assignees
 
     tags = sg_ay_dict.get("tags")
     if tags:

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1354,10 +1354,13 @@ def update_ay_entity_custom_attributes(
             except ValueError as e:
                 logging.warning(f"Status sync not implemented: {e}")
         elif ay_attrib == "assignees":
-            try:
+            if hasattr(ay_entity, "assignees"):
                 ay_entity.assignees = attrib_value
-            except ValueError as e:
-                logging.warning(f"Assignees sync not implemented: {e}")
+            else:
+                logging.warning(
+                    "Assignees sync not available with current"
+                    " ayon-python-api version."
+                )
         else:
             ay_entity.attribs.set(ay_attrib, attrib_value)
 

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -185,7 +185,7 @@ def _sg_to_ay_dict(
             # If no value in SG entity skip
             if sg_value is None:
                 continue
-            
+
             if ay_attrib in exception_attribs:
                 sg_ay_dict[ay_attrib] = sg_value
             else:
@@ -947,7 +947,7 @@ def get_sg_entity_as_ay_dict(
 
     if not sg_entity:
         return {}
-    
+
     _add_task_assignees(sg_entity)
 
     sg_ay_dict = _sg_to_ay_dict(

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1346,13 +1346,9 @@ def update_ay_entity_custom_attributes(
                 ay_entity.status = new_status.name
             else:
                 logging.warning(
-                    f"Status '{attrb_value}' not available"
-                    f" for {entity.entity_type}."
+                    f"Status '{attrib_value}' not available"
+                    f" for {ay_entity.entity_type}."
                 )
-            try:
-                ay_entity.status = new_status_name
-            except ValueError as e:
-                logging.warning(f"Status sync not implemented: {e}")
         elif ay_attrib == "assignees":
             if hasattr(ay_entity, "assignees"):
                 ay_entity.assignees = attrib_value

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1494,6 +1494,7 @@ def _add_task_assignees(sg_entity):
     # to just a list of the login names as used in AYON DB
     # so it's easier later to set
     task_assignees = sg_entity.get("task_assignees")
+    log.debug(f"Received '{task_assignees}' from SG.")
     if not task_assignees:
         return
 
@@ -1504,6 +1505,8 @@ def _add_task_assignees(sg_entity):
         if assignee["type"] != "HumanUser":
             continue
         ayon_user = get_user_by_sg_id(assignee["id"])
+        if not ayon_user:
+            log.warning(f"Didn't find user for '{assignee['id']}'")
         task_assignees_list.append(ayon_user["name"])
-
+    log.debug(f"Adding '{task_assignees_list}' from SG.")
     sg_entity["task_assignees"] = task_assignees_list

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1417,8 +1417,8 @@ def create_new_ayon_entity(
         # not the `short_name` (which is what we get from SG) so we convert
         # the short name back to the long name before setting it
         status_mapping = {
-            status.short_name: status.name for status in
-            entity_hub.project_entity.statuses
+            status.short_name: status.name
+            for status in entity_hub.project_entity.statuses
         }
         new_status_name = status_mapping.get(status)
         if not new_status_name:

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1515,6 +1515,7 @@ def _add_task_assignees(sg_entity):
         ayon_user_name = get_ayon_name_by_sg_id(assignee["id"])
         if not ayon_user_name:
             log.warning(f"Didn't find user for '{assignee['id']}'")
+            continue
         task_assignees_list.append(ayon_user_name)
     log.debug(f"Adding '{task_assignees_list}' from SG.")
     sg_entity["task_assignees"] = task_assignees_list

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1458,22 +1458,23 @@ def create_new_ayon_entity(
     return ay_entity
 
 
-def get_user_by_sg_id(sg_user_id):
-    """Returns ayon user for particular `sg_user_id`
+def get_ayon_name_by_sg_id(sg_user_id):
+    """Returns AYON user name for particular `sg_user_id`
 
-    Calls SG addon endpoint to query 'users' table
+    Calls SG addon endpoint to query 'users' table limit need to loop through
+    all users.
 
     Args:
         sg_user_id (str)
     Returns:
-        (Optional[dict[str, Any]])
+        (Optional[str])
     """
     addon_name = ayon_api.get_service_addon_name()
     addon_version = ayon_api.get_service_addon_version()
     variant = ayon_api.get_default_settings_variant()
     endpoint_url = (
         f"addons/{addon_name}/{addon_version}/"
-        f"get_user_by_sg_id/{sg_user_id}"
+        f"get_ayon_name_by_sg_id/{sg_user_id}"
         f"?variant={variant}"
     )
 
@@ -1500,9 +1501,9 @@ def _add_task_assignees(sg_entity):
         # TODO: add support for group assignments
         if assignee["type"] != "HumanUser":
             continue
-        ayon_user = get_user_by_sg_id(assignee["id"])
-        if not ayon_user:
+        ayon_user_name = get_ayon_name_by_sg_id(assignee["id"])
+        if not ayon_user_name:
             log.warning(f"Didn't find user for '{assignee['id']}'")
-        task_assignees_list.append(ayon_user["name"])
+        task_assignees_list.append(ayon_user_name)
     log.debug(f"Adding '{task_assignees_list}' from SG.")
     sg_entity["task_assignees"] = task_assignees_list

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -666,6 +666,10 @@ def get_sg_entities(
             if task_assignees:
                 task_assignees_list = []
                 for assignee in task_assignees:
+                    # Skip task assignments that aren't from a human user (i.e. groups)
+                    # TODO: add support for group assignments
+                    if assignee["type"] != "HumanUser":
+                        continue
                     sg_user = get_sg_user_by_id(
                         sg_session, assignee["id"], extra_fields=["login"]
                     )
@@ -743,6 +747,10 @@ def get_sg_entity_as_ay_dict(
     if task_assignees:
         task_assignees_list = []
         for assignee in task_assignees:
+            # Skip task assignments that aren't from a human user (i.e. groups)
+            # TODO: add support for group assignments
+            if assignee["type"] != "HumanUser":
+                continue
             sg_user = get_sg_user_by_id(
                 sg_session, assignee["id"], extra_fields=["login"]
             )

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1397,6 +1397,9 @@ def create_new_ayon_entity(
             attribs=sg_ay_dict["attribs"],
             data=sg_ay_dict["data"]
         )
+    elif sg_ay_dict["type"].lower() == "version":
+        log.warning("Cannot create new versions yet.")
+        return
     else:
         ay_entity = entity_hub.add_new_folder(
             folder_type=sg_ay_dict["folder_type"],

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -76,6 +76,12 @@ class ShotgridTransmitter:
                 for attr in custom_attribs_map
                 if attr["sg"]
             }
+            self.custom_attribs_map.update({
+                "status": "status_list",
+                "tags": "tags",
+                "assignees": "task_assignees"
+            })
+
             self.custom_attribs_types = {
                 attr["sg"]: (attr["type"], attr["scope"])
                 for attr in custom_attribs_map
@@ -142,6 +148,7 @@ class ShotgridTransmitter:
             "entity.folder.attrib_changed",
             "entity.folder.status_changed",
             "entity.folder.tags_changed",
+            "entity.version.status_changed",
         ]
 
         while True:

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -139,6 +139,7 @@ class ShotgridTransmitter:
             "entity.task.deleted",
             "entity.task.renamed",
             "entity.task.create",
+            "entity.task.assignees_changed",
             "entity.task.attrib_changed",
             "entity.task.status_changed",
             "entity.task.tags_changed",


### PR DESCRIPTION
## Changelog Description
This adds support to sync task assignees to AYON tasks and statuses on all entities (including Versions)

## Testing notes:
1. synchronize users first
<img width="1016" alt="chrome_wk2mdKuBG1" src="https://github.com/user-attachments/assets/97d712bc-d73d-43c8-b7bf-6d811d7021e1">
2. Assign users to at least 1 access group in `manageProjects/userSettings?project=YOUR_PROJECT`
    without it sync of assignees from SG>AYON wont work, but will not fail. Assigning users to AYON project must be implemented during event based user synch.
2. experiment with adding/removing assignee/tags/status in AYON (right column in `Editor`)
<img width="377" alt="chrome_gQcwKQRGad" src="https://github.com/user-attachments/assets/f6c3f78b-1e68-491e-a8b7-81fe0ed26d79">

3. do the same on SG side

(^edited by kalisp)

## original PR description kept for posterity
This adds support to sync task assignees to AYON tasks and statuses on all entities (including Versions)

This requires both of these PRs:
* https://github.com/ynput/ayon-python-api/pull/157
* https://github.com/ynput/ayon-python-api/pull/158

AY-7217