### PR TITLE
Ignore events by default unless it's a supported event by non-api user

### DIFF
--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -236,7 +236,7 @@ class ShotgridListener:
                     if not event:
                         continue
 
-                    ignore_event = False
+                    ignore_event = True
                     last_event_id = event["id"]
 
                     if (


### PR DESCRIPTION
There was a bug where SG events weren't being ignored by default, the default should be to ignore, otherwise user API events were causing a recursion of updates (and failing to do so)