### PR TITLE
Refactor code to include new event hash generation function

### DIFF
--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -6,6 +6,7 @@ Shotgrid and converts them to Ayon events, and can be configured from the Ayon
 Addon settings page.
 """
 import sys
+import json
 import time
 import signal
 import socket
@@ -188,9 +189,11 @@ class ShotgridListener:
             return None
         data = response.data["data"]
         for node in data["events"]["edges"]:
+            summary = node["node"]["summary"]
+            summary_data = json.loads(summary)
             # TODO: remove hash in future since it is only used
             #       as backward compatibility
-            if node["node"]["summary"].get("sg_event_id"):
+            if summary_data.get("sg_event_id"):
                 return node["node"]["summary"]["sg_event_id"]
             else:
                 return int(node["node"]["hash"])

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -194,7 +194,7 @@ class ShotgridListener:
             # TODO: remove hash in future since it is only used
             #       as backward compatibility
             if summary_data.get("sg_event_id"):
-                return node["node"]["summary"]["sg_event_id"]
+                return summary_data["sg_event_id"]
             else:
                 return int(node["node"]["hash"])
         return None

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -195,8 +195,10 @@ class ShotgridListener:
             #       as backward compatibility
             if summary_data.get("sg_event_id"):
                 return summary_data["sg_event_id"]
-            else:
-                return int(node["node"]["hash"])
+
+            # return it old way
+            # TODO: remove in future
+            return int(node["node"]["hash"])
         return None
 
     def _get_last_event_processed(self, sg_filters):

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -384,6 +384,7 @@ class ShotgridListener:
                 "sg_event_id": payload_id,
             },
             payload={
+                "message": json.dumps(payload, indent=2),
                 "action": "shotgrid-event",
                 "user_name": user_name,
                 "project_name": project_name,

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -214,6 +214,7 @@ class ShotgridProcessor:
                     event_id_text = "."
 
                 if not payload:
+                    # TODO: maybe remove this - unrealistic scenario
                     ayon_api.update_event(
                         event["id"],
                         description=(
@@ -235,7 +236,7 @@ class ShotgridProcessor:
                                 "Processing event with Handler "
                                 f"{payload['action']}..."
                             ),
-                            status="finished"
+                            status="in_progress",
                         )
                         self.log.debug(
                             f"processing event {pformat(payload)}")

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -204,19 +204,25 @@ class ShotgridProcessor:
                 # Get source event because it is having payload to process
                 source_event = ayon_api.get_event(event["dependsOn"])
                 payload = source_event["payload"]
+                summary = source_event["summary"]
+
+                if source_sg_event_id := summary.get("sg_event_id"):
+                    event_id_text = (
+                        f". Shotgrid Event ID: {source_sg_event_id}."
+                    )
+                else:
+                    event_id_text = "."
 
                 if not payload:
                     ayon_api.update_event(
                         event["id"],
                         description=(
-                            "Unable to process the event "
+                            f"Unable to process the event{event_id_text} > "
                             f"<{source_event['id']}> since it has no "
                             "Shotgrid Payload!"
                         ),
                         status="finished"
                     )
-                    ayon_api.update_event(
-                        source_event["id"], status="finished")
                     continue
 
                 for handler in self.handlers_map.get(payload["action"], []):
@@ -246,29 +252,23 @@ class ShotgridProcessor:
                         ayon_api.update_event(
                             event["id"],
                             status="failed",
-                            description="An error ocurred while processing",
+                            description=(
+                                "An error ocurred while processing"
+                                f"{event_id_text}"
+                            ),
                             payload={
                                 "message": traceback.format_exc(),
                             },
                         )
-                        ayon_api.update_event(
-                            source_event["id"],
-                            status="failed",
-                            description=(
-                                "The service `processor` was unable to "
-                                "process this event. Check the `shotgrid.proc`"
-                                f" <{event['id']}> event for more info."
-                            )
-                        )
 
                 self.log.info(
                     "Event has been processed... setting to finished!")
+
                 ayon_api.update_event(
                     event["id"],
-                    description="Event processed successfully.",
-                    status="finished"
+                    description=f"Event processed successfully{event_id_text}",
+                    status="finished",
                 )
-                ayon_api.update_event(source_event["id"], status="finished")
 
             except Exception:
                 self.log.error(traceback.format_exc())

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1,4 +1,6 @@
 import os
+import json
+import hashlib
 import logging
 import collections
 from typing import Dict, Optional, Union
@@ -68,6 +70,24 @@ def get_logger(name: str) -> logging.Logger:
 
 # create logger
 log = get_logger(__name__)
+
+
+def get_event_hash(event_topic: str, event_id: int) -> str:
+    """Create a SHA-256 hash from the event topic and event ID.
+
+    Arguments:
+        event_topic (str): The event topic.
+        event_id (int): The event ID.
+
+    Returns:
+        str: The SHA-256 hash.
+    """
+    data = {
+        "event_topic": event_topic,
+        "event_id": event_id,
+    }
+    json_data = json.dumps(data)
+    return hashlib.sha256(json_data.encode("utf-8")).hexdigest()
 
 
 def _sg_to_ay_dict(


### PR DESCRIPTION
- Created new function `get_event_hash` in utils.py to generate SHA-256 hash from event topic and ID
- Added import for `get_event_hash` in listener.py
- Updated usage of `get_event_hash` in ShotgridListener class methods
- dispathing leecher events with summary with sg_event_id instead of adding it into ayon event hash
- Removing redundant source event update in processor
- Improving proc event description to better reflect on source SG event ID
- Leecher events are displaying SG payload in the message body
