### PR TITLE
Improving leecher, processor with project sync events

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -11,7 +11,7 @@
     <h1>ShotGrid Sync</h1>
     <p>
         From this page you can Import projects from ShotGrid or trigger a project Sync!<br>
-        In order for the Synchronization to work, a <b><code>ShotgridProcessor</code> <a target="_parent" href="/services">service</a> must be running</b>, this page will only create <a target="_parent" href="/events"> events (with the topic: "shotgrid.event") </a> for the processor to handle.
+        In order for the Synchronization to work, a <b><code>ShotgridProcessor</code> <a target="_parent" href="/services">service</a> must be running</b>, this page will only create <a target="_parent" href="/events"> events (with the topic: "shotgrid.event.project.sync") </a> for the processor to handle.
     </p>
     <p>To be able to import a project from ShotGrid, there are two minimum requirements on ShotGrid:</p>
         <ul>

--- a/frontend/dist/shotgrid-addon.js
+++ b/frontend/dist/shotgrid-addon.js
@@ -213,15 +213,15 @@ const getAyonProjects = async () => {
 
 
 const syncShotgridToAyon = async (projectName, projectCode) => {
-  /* Spawn an AYON Event of topic "shotgrid.event" to synchronize a project
+  /* Spawn an AYON Event of topic "shotgrid.event.project.sync" to synchronize a project
   from Shotgrid into AYON. */
   call_result_paragraph = document.getElementById("call-result");
 
   dispatch_event = await ayonAPI
     .post("/api/events", {
-      "topic": "shotgrid.event",
+      "topic": "shotgrid.event.project.sync",
       "project": projectName,
-      "description": `Synchronize Project ${projectName} from Shotgrid.`,
+      "description": `Synchronize Project '${projectName}' from Shotgrid.`,
       "payload": {
         "action": "sync-from-shotgrid",
         "project_name": projectName,
@@ -244,13 +244,13 @@ const syncShotgridToAyon = async (projectName, projectCode) => {
 }
 
 const syncAyonToShotgrid = async (projectName, projectCode) => {
-  /* Spawn an AYON Event of topic "shotgrid.event" to synchronize a project
-  from AYON into Shotgrid. */
+  /* Spawn an AYON Event of topic "shotgrid.event.project.sync"
+  to synchronize a project from AYON into Shotgrid. */
   call_result_paragraph = document.getElementById("call-result");
 
   dispatch_event = await ayonAPI
     .post("/api/events", {
-      "topic": "shotgrid.event",
+      "topic": "shotgrid.event.project.sync",
       "project": projectName,
       "description": `Synchronize Project ${projectName} from AYON.`,
       "payload": {

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -29,7 +29,7 @@ import shotgun_api3
 
 # TODO: remove hash in future since it is only used as backward compatibility
 LAST_EVENT_QUERY = """query LastShotgridEvent($eventTopic: String!) {
-  events(last: 1, topics: [$eventTopic]) {
+  events(last: 20, topics: [$eventTopic]) {
     edges {
       node {
         hash
@@ -191,14 +191,20 @@ class ShotgridListener:
         for node in data["events"]["edges"]:
             summary = node["node"]["summary"]
             summary_data = json.loads(summary)
-            # TODO: remove hash in future since it is only used
-            #       as backward compatibility
+
             if summary_data.get("sg_event_id"):
                 return summary_data["sg_event_id"]
 
             # return it old way
-            # TODO: remove in future
-            return int(node["node"]["hash"])
+            # TODO: remove hash in future since it is only used
+            #       as backward compatibility
+            try:
+                return int(node["node"]["hash"])
+            except ValueError:
+                # if hash is not an integer this can happen if project sync
+                # is using old topic `shotgrid.event`
+                pass
+
         return None
 
     def _get_last_event_processed(self, sg_filters):

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -189,7 +189,7 @@ class ShotgridProcessor:
         while True:
             try:
                 event = ayon_api.enroll_event_job(
-                    "shotgrid.event",
+                    "shotgrid.event*",
                     "shotgrid.proc",
                     socket.gethostname(),
                     description="Enrolling to any `shotgrid.event` Event...",


### PR DESCRIPTION
- fixing issue with ValueError: int(node["node"]["hash"]) / `invalid literal for int() with base 10`
- differentiate project sync with different topic
- processor accepts both types of topics since it is inherited under `shotgrid.event*`