### PR TITLE
Filling SG versions path_to_frames

### DIFF
--- a/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_version.py
+++ b/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_version.py
@@ -57,6 +57,14 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
             if f".{representation['ext']}" in VIDEO_EXTENSIONS:
                 found_reviewable = True
                 data_to_update["sg_path_to_movie"] = local_path
+                for representationSecondary in instance.data.get("representations", []):
+                    if f".{representationSecondary['ext']}" in IMAGE_EXTENSIONS and "thumbnail" not in f".{representationSecondary['name']}":
+                        frames_path = get_publish_repre_path(
+                            instance, representationSecondary, False
+                        )
+                        path_to_frames = re.sub(r"\.\d+\.", ".####.", frames_path)
+                        data_to_update["sg_path_to_frames"] = path_to_frames
+                        self.log.debug(f"setting path_to_frames to {path_to_frames}")
                 if (
                     "slate" in instance.data["families"]
                     and "slate-frame" in representation["tags"]
@@ -72,6 +80,15 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
                     "sg_path_to_movie": path_to_frame,
                     "sg_path_to_frames": path_to_frame,
                 })
+                for representationSecondary in instance.data.get("representations", []):
+                    if f".{representationSecondary['ext']}" in IMAGE_EXTENSIONS:
+                        if "thumb" not in f".{representationSecondary['name']}" and "review" not in f".{representationSecondary['name']}":
+                            frames_path = get_publish_repre_path(
+                                instance, representationSecondary, False
+                            )
+                            path_to_frames = re.sub(r"\.\d+\.", ".%04d.", frames_path)
+                            data_to_update["sg_path_to_frames"] = path_to_frames
+                            self.log.debug(f"setting path_to_frames to {path_to_frames}")
 
                 if "slate" in instance.data["families"]:
                     data_to_update["sg_frames_have_slate"] = True

--- a/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_version.py
+++ b/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_version.py
@@ -88,10 +88,10 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
 
                 elif f".{representation['ext']}" in IMAGE_EXTENSIONS:
                     found_reviewable = True
-                    data_to_update |= {
+                    data_to_update.update({
                         "sg_path_to_movie": local_path,
                         "sg_path_to_frames": local_path,
-                    }
+                    })
 
                     if "slate" in instance.data["families"]:
                         data_to_update["sg_frames_have_slate"] = True
@@ -99,10 +99,10 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
         if not found_reviewable and thumbnail_path is not None:
             # create a thumbnail data to update
             found_reviewable = True
-            data_to_update |= {
+            data_to_update.update({
                 "sg_path_to_movie": thumbnail_path,
                 "sg_path_to_frames": thumbnail_path,
-            }
+            })
 
         # If there's no data to set/update, skip creation of SG version
         if not found_reviewable or "workfile" in f"{instance.data['productName']}":


### PR DESCRIPTION
## Changelog Description
My studio requires uploaded versions' sg_path_to_frames field to be filled in with the EXRs to review / deliver. This checks all representations attached to the product, does basic filtering and takes the path from there. 


## Additional info
If a product has >1 compatible image representations (created through the oiiotool for example), the last representation's path is used. Last alphabetically, as far as I can tell. Perhaps a tag could be added on the Extract Review output definition to specify which representation name to use, ie "path_to_frames:exr2065". But I'm not sure if there's existing conventions for this, and we needed a hotfix


## Testing notes:

1. Publish a review to SG. I did a nuke render with stock Extract Review settings
2. Check "sg_path_to_frames" field against the representation's path in ayon
