### PR TITLE
Ignoring Task entities with no step key

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -2,8 +2,9 @@ from ayon_server.entities.core.attrib import attribute_library
 from ayon_server.settings import BaseSettingsModel, SettingsField
 from ayon_server.settings.enum import (
     secrets_enum,
+    task_types_enum,
     anatomy_presets_enum,
-    folder_types_enum
+    folder_types_enum,
 )
 
 
@@ -214,8 +215,14 @@ class FolderReparentingModel(BaseSettingsModel):
     )
 
 class ShotgridCompatibilitySettings(BaseSettingsModel):
-    """ Settings to define relationships between ShotGrid and AYON.
-    """
+    """Settings to define relationships between ShotGrid and AYON."""
+
+    default_task_type: str = SettingsField(
+        default="Generic",
+        title="Default Task Type",
+        enum_resolver=task_types_enum,
+        description=("Default Task Type for SG tasks with missing pipeline step"),
+    )
     shotgrid_enabled_entities: list[str] = SettingsField(
         title="ShotGrid Enabled Entities",
         default_factory=default_shotgrid_enabled_entities,

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -262,7 +262,8 @@ class AyonShotgridHub:
                     self._sg,
                     self.sg_enabled_entities,
                     self.sg_project_code_field,
-                    self.custom_attribs_map
+                    self.custom_attribs_map,
+                    self.settings,
                 )
 
             case "shotgrid":
@@ -355,6 +356,7 @@ class AyonShotgridHub:
                     self._ay_project,
                     self.sg_enabled_entities,
                     self.sg_project_code_field,
+                    self.settings,
                     self.custom_attribs_map,
                 )
 
@@ -368,7 +370,8 @@ class AyonShotgridHub:
                     sg_event_meta,
                     self._sg,
                     self._ay_project,
-                    self.sg_project_code_field
+                    self.sg_project_code_field,
+                    self.settings,
                 )
 
             case _:

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -1,6 +1,6 @@
 import collections
 import shotgun_api3
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Any
 
 import ayon_api
 from ayon_api.entity_hub import (
@@ -36,6 +36,7 @@ def match_ayon_hierarchy_in_shotgrid(
     sg_enabled_entities: List[str],
     project_code_field: str,
     custom_attribs_map: Dict[str, str],
+    addon_settings: Dict[str, Any],
 ):
     """Replicate an AYON project into Shotgrid.
 
@@ -52,6 +53,7 @@ def match_ayon_hierarchy_in_shotgrid(
         sg_enabled_entities (list): List of Shotgrid entities to be enabled.
         custom_attribs_map (dict): Dictionary of extra attributes to
             store in the SG entity.
+        addon_settings (dict): The addon settings.
     """
     log.info("Getting AYON entities.")
     entity_hub.query_entities_from_server()
@@ -63,6 +65,7 @@ def match_ayon_hierarchy_in_shotgrid(
         sg_enabled_entities,
         project_code_field,
         custom_attribs_map,
+        addon_settings=addon_settings,
     )
 
     ay_entity_deck = collections.deque()

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -58,6 +58,7 @@ def match_shotgrid_hierarchy_in_ayon(
         sg_enabled_entities,
         project_code_field,
         custom_attribs_map,
+        addon_settings=addon_settings,
     )
 
     sg_ay_dicts_deck = collections.deque()

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -27,7 +27,7 @@ import collections
 
 import shotgun_api3
 import ayon_api
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 
 from utils import (
     create_new_ayon_entity,
@@ -79,6 +79,8 @@ def create_ay_entity_from_sg_event(
         ay_entity (ayon_api.entity_hub.EntityHub.Entity): The newly
             created entity.
     """
+    default_task_type = addon_settings[
+        "compatibility_settings"]["default_task_type"]
     sg_parent_field = get_sg_entity_parent_field(
         sg_session,
         sg_project,
@@ -96,6 +98,7 @@ def create_ay_entity_from_sg_event(
         sg_event["entity_type"],
         sg_event["entity_id"],
         project_code_field,
+        default_task_type,
         custom_attribs_map=custom_attribs_map,
         extra_fields=extra_fields,
     )
@@ -147,6 +150,7 @@ def create_ay_entity_from_sg_event(
                 sg_ay_dict["data"][sg_parent_field]["type"],
                 sg_ay_dict["data"][sg_parent_field]["id"],
                 project_code_field,
+                default_task_type,
             )
 
             if sg_ay_parent_dict["attribs"].get("shotgridType") == "Asset":
@@ -160,6 +164,7 @@ def create_ay_entity_from_sg_event(
                     sg_ay_dict["data"][sg_parent_field]["type"],
                     sg_ay_dict["data"][sg_parent_field]["id"],
                     project_code_field,
+                    default_task_type,
                     custom_attribs_map=custom_attribs_map,
                     extra_fields=extra_fields,
                 )
@@ -221,6 +226,8 @@ def _get_ayon_parent_entity(
         ay_entity (ayon_api.entity_hub.EntityHub.Entity):
             FolderEntity|ProjectEntity
     """
+    default_task_type = addon_settings[
+        "compatibility_settings"]["default_task_type"]
     shotgrid_type = sg_ay_dict["attribs"][SHOTGRID_TYPE_ATTRIB]
     sg_parent = sg_ay_dict["data"].get(sg_parent_field)
     ay_parent_entity = None
@@ -267,6 +274,7 @@ def _get_ayon_parent_entity(
                 sg_parent["type"],
                 sg_parent["id"],
                 project_code_field,
+                default_task_type,
             )
 
             log.debug(f"ShotGrid Parent entity: {sg_parent_entity_dict}")
@@ -312,7 +320,8 @@ def update_ayon_entity_from_sg_event(
     ayon_entity_hub: ayon_api.entity_hub.EntityHub,
     sg_enabled_entities: List[str],
     project_code_field: str,
-    custom_attribs_map: Optional[Dict[str, str]] = None
+    addon_settings: Dict[str, Any],
+    custom_attribs_map: Optional[Dict[str, str]] = None,
 ):
     """Try to update an entity in AYON.
 
@@ -323,6 +332,7 @@ def update_ayon_entity_from_sg_event(
         ayon_entity_hub (ayon_api.entity_hub.EntityHub): The AYON EntityHub.
         sg_enabled_entities (list[str]): List of entity strings enabled.
         project_code_field (str): The ShotGrid project code field.
+        addon_settings (dict): A dictionary of Settings.
         custom_attribs_map (dict): A dictionary that maps ShotGrid
             attributes to AYON attributes.
 
@@ -330,11 +340,15 @@ def update_ayon_entity_from_sg_event(
         ay_entity (ayon_api.entity_hub.EntityHub.Entity): The modified entity.
 
     """
+    default_task_type = addon_settings[
+        "compatibility_settings"]["default_task_type"]
+
     sg_ay_dict = get_sg_entity_as_ay_dict(
         sg_session,
         sg_event["entity_type"],
         sg_event["entity_id"],
         project_code_field,
+        default_task_type,
         custom_attribs_map=custom_attribs_map
     )
 
@@ -416,6 +430,7 @@ def remove_ayon_entity_from_sg_event(
     sg_session: shotgun_api3.Shotgun,
     ayon_entity_hub: ayon_api.entity_hub.EntityHub,
     project_code_field: str,
+    addon_settings: Dict[str, Any],
 ):
     """Try to remove an entity in AYON.
 
@@ -424,12 +439,17 @@ def remove_ayon_entity_from_sg_event(
         sg_session (shotgun_api3.Shotgun): The ShotGrid API session.
         ayon_entity_hub (ayon_api.entity_hub.EntityHub): The AYON EntityHub.
         project_code_field (str): The ShotGrid field that contains the AYON ID.
+        addon_settings (dict): A dictionary of Settings.
     """
+    default_task_type = addon_settings[
+        "compatibility_settings"]["default_task_type"]
+
     sg_ay_dict = get_sg_entity_as_ay_dict(
         sg_session,
         sg_event["entity_type"],
         sg_event["entity_id"],
         project_code_field,
+        default_task_type,
         retired_only=True
     )
 
@@ -439,6 +459,7 @@ def remove_ayon_entity_from_sg_event(
             sg_event["entity_type"],
             sg_event["entity_id"],
             project_code_field,
+            default_task_type,
             retired_only=False,
         )
         if sg_ay_dict:

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -116,19 +116,23 @@ def _sg_to_ay_dict(
     if sg_entity["type"] == "Task":
         ay_entity_type = "task"
         if not sg_entity["step"]:
-            raise ValueError(
+            log.warning(
                 f"Task {sg_entity} has no Pipeline Step assigned."
             )
+            task_type = None
+        else:
+            task_type = sg_entity["step"]["name"]
 
         label = sg_entity["content"]
-        task_type = sg_entity["step"]["name"]
 
         if not label and not task_type:
             raise ValueError(f"Unable to parse Task {sg_entity}")
+
         if label:
             name = slugify_string(label)
-        else:
+        elif task_type:
             name = slugify_string(task_type)
+
 
     elif sg_entity["type"] == "Project":
         name = slugify_string(sg_entity[project_code_field])

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -121,7 +121,7 @@ def _sg_to_ay_dict(
     if sg_entity["type"] == "Task":
         ay_entity_type = "task"
         if not sg_entity["step"]:
-            log.warning(
+            log.debug(
                 f"Task {sg_entity} has no Pipeline Step assigned. "
                 "Task type set from settings."
             )

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -97,6 +97,7 @@ def _sg_to_ay_dict(
     sg_entity: dict,
     project_code_field: str,
     custom_attribs_map: dict,
+    default_task_type: str,
 ) -> dict:
     """Morph a ShotGrid entity dict into an ayon-api Entity Hub compatible one.
 


### PR DESCRIPTION
# Change description
Some productions might be using tasks without SG task entity `step` key. This will change will not raise the missing key and therefore it will allow to sync tasks into project. New settings for defining default task type were added under Compatibility Settigs section. This way we can assign task type to those tasks which are missing pipeline step at SG entity. 

# Testing steps:
1. Make sure `ayon+settings://shotgrid/compatibility_settings/default_task_type` is set at your Project settings with existing Anatomy Task type. Ideally create new one and name it `Unknown`
2. Go to any of yours test project at SG and create new task under any Shot or Asset.
3. Make usre the autosync is set to both direction on SG and AY side.
4. Task shoud be created and the default task type is assigned to it. 
5. Remove the task on AY side and notice that after refreash it had been also retired on SG side.