### PR TITLE
save password to keyring only if password is present

### DIFF
--- a/client/ayon_shotgrid/lib/credentials.py
+++ b/client/ayon_shotgrid/lib/credentials.py
@@ -137,8 +137,9 @@ def save_local_login(username, password):
     """Save the Shotgrid Login entry from the local registry. """
     reg = AYONSecureRegistry("shotgrid/user")
     reg.set_item("value", username)
-    reg = AYONSecureRegistry("shotgrid/pass")
-    reg.set_item("value", password)
+    if password:
+        reg = AYONSecureRegistry("shotgrid/pass")
+        reg.set_item("value", password)
 
 
 def clear_local_login():


### PR DESCRIPTION
## Changelog Description
This mini PR prevents saving password to local keyring if it's not present, e.g. when using the login method `via shared api key`.


## Additional info
Reasoning for this is that when trying to connect to ShotGrid using the login method `shared api key` it would throw the following stacktrace:

```log
Traceback (most recent call last):
  File "<REDACTED>/Library/Application Support/AYON/addons/shotgrid_0.4.4-hotfix.1/ayon_shotgrid/tray/sg_login_dialog.py", line 147, in check_sg_credentials
    self.set_local_login()
  File "<REDACTED>/Library/Application Support/AYON/addons/shotgrid_0.4.4-hotfix.1/ayon_shotgrid/tray/sg_login_dialog.py", line 106, in set_local_login
    credentials.save_local_login(sg_username, None)
  File "<REDACTED>/Library/Application Support/AYON/addons/shotgrid_0.4.4-hotfix.1/ayon_shotgrid/lib/credentials.py", line 141, in save_local_login
    reg.set_item("value", password)
  File "<REDACTED>/Library/Application Support/AYON/addons/core_0.4.3-bpc.1/ayon_core/lib/local_settings.py", line 80, in set_item
    keyring.set_password(self._name, name, value)
  File "/Applications/AYON 1.0.4.app/Contents/MacOS/dependencies/keyring/core.py", line 61, in set_password
    get_keyring().set_password(service_name, username, password)
  File "/Applications/AYON 1.0.4.app/Contents/MacOS/dependencies/keyring/backends/macOS/__init__.py", line 38, in set_password
    api.set_generic_password(self.keychain, service, username, password)
  File "/Applications/AYON 1.0.4.app/Contents/MacOS/dependencies/keyring/backends/macOS/api.py", line 230, in set_generic_password
    password = password.encode('utf-8')
AttributeError: 'NoneType' object has no attribute 'encode'
```


## Testing notes:

1. run AYON Launcher under macOS
2. configure `ayon-shotgrid` to use login method `via shared api key`
3. specify your SG username in the login widget


## ToDo

- although logging in works with this PR it doesn't update the SG tray widget accordingly. it should show the currently puppeteered user
 
<img width="410" alt="Screenshot 2024-09-19 at 16 35 04" src="https://github.com/user-attachments/assets/9701c5ba-85ee-4d9a-92f0-8731d103afab">

