### PR TITLE
Chore: Use 'AYON' in logs and docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Shotgrid integration for Ayon
+# Shotgrid integration for AYON
 
-This project provides three elements for the Ayon pipeline:
- * server/ - The Ayon Backend Addon.
+This project provides three elements for the AYON pipeline:
+ * server/ - The AYON Backend Addon.
  * frontend/ - The AYON server Shotgrid settings tab.
  * client/ - The AYON desktop integration.
  * services/ - Standalone dockerized daemons that act based on events (aka `leecher` and `processors`).
@@ -22,7 +22,7 @@ We can now go into the `Settings > Studio settings > Shotgrid` page in AYON and 
 
 
 ## Desktop application
-When launching Ayon for the first time you'll be asked to provide a login (only the username) for Shotgrid, this is the user that will be used for publishing.
+When launching AYON for the first time you'll be asked to provide a login (only the username) for Shotgrid, this is the user that will be used for publishing.
 After providing a login people can publish normally, the integartion will ensure that the user can connect to Shotgrid, that has the correct permissions and will create the Version and PublishedFile in Shotgrid if the publish is succesful.
 
 ## Services
@@ -35,7 +35,7 @@ The three provided services are:
  * `leecher` - Periodically queries the `EventLogEntry` table on Shotgrid and ingests any event that interests us dispatching it as a `shotgrid.event`, this will only query projects that have the "Ayon Auto Sync" field enabled.
  * `transmitter` - Periodically check for new events in AYON of topic `entity.*`, and push any changes to Shotgrid, only affects to projects that have the "Ayon Auto Sync" field enabled.
 
-The most straighforward way to get this up and running is by using ASH (Ayon Service Host), after loading the Addon on the server, you should be able to spawn services in the "Services" page.
+The most straighforward way to get this up and running is by using ASH (AYON Service Host), after loading the Addon on the server, you should be able to spawn services in the "Services" page.
 
 ### Development
 There's a single `Makefile` at the root of the `services` folder, which is used to `build` the docker images and to run the services locally with the `dev` target, this is UNIX only for the time being, running `make` without argument will print information as to how to run use it.
@@ -46,7 +46,7 @@ To build the docker images you can run `make SERVICE=<service-name> build`, so f
 #### Running the Service locally
 In order to run the service locally we need to specify certain environment variables, to do so, copy the `sample_env` file, rename to `.env` and fill the fields acordingly:
 ```
-AYON_API_KEY=<AYON_API_KEY> # You can create a `service` user in Ayon, and then get the Key from there.
+AYON_API_KEY=<AYON_API_KEY> # You can create a `service` user in AYON, and then get the Key from there.
 AYON_SERVER_URL=<YOUR_AYON_URL>
 PYTHONDONTWRITEBYTECODE=1
 ```
@@ -60,7 +60,7 @@ You should now see something similar to:
 ```sh
 INFO       Initializing the Shotgrid Processor.
 DEBUG      Found these handlers: {'create-project': [<module 'project_sync'>], 'sync-from-shotgrid': [<module 'sync_from_shotgrid'>], 'shotgrid-event': [<module 'update_from_shotgrid'>]}
-INFO       Start enrolling for Ayon `shotgrid.event` Events...
+INFO       Start enrolling for AYON `shotgrid.event` Events...
 INFO       Querying for new `shotgrid.event` events...
 INFO       No event of origin `shotgrid.event` is pending.
 ```

--- a/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_version.py
+++ b/client/ayon_shotgrid/plugins/publish/integrate_shotgrid_version.py
@@ -16,7 +16,7 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
     label = "Shotgrid Version"
 
     # Dictionary of SG fields we want to update that map to other fields in the
-    # Ayon entity
+    # AYON entity
     fields_to_add = {
         "comment": (str, "description"),
         "productType": (str, "sg_version_type"),

--- a/client/ayon_shotgrid/plugins/publish/validate_shotgrid_user.py
+++ b/client/ayon_shotgrid/plugins/publish/validate_shotgrid_user.py
@@ -20,7 +20,7 @@ class ValidateShotgridUser(pyblish.api.ContextPlugin):
         if not (user_login and sg_session and sg_project):
             raise PublishValidationError("Missing Shotgrid Credentials")
 
-        self.log.info("Login ShotGrid set in Ayon is {}".format(user_login))
+        self.log.info("Login ShotGrid set in AYON is {}".format(user_login))
         self.log.info("Current ShotGrid Project is {}".format(sg_project))
 
         sg_user = sg_session.find_one(

--- a/client/ayon_shotgrid/tray/sg_login_dialog.py
+++ b/client/ayon_shotgrid/tray/sg_login_dialog.py
@@ -20,7 +20,7 @@ class SgLoginDialog(QtWidgets.QDialog):
         self.addon = addon
         self.login_type = self.addon.get_client_login_type()
 
-        self.setWindowTitle("Ayon - Shotgrid Login")
+        self.setWindowTitle("AYON - Shotgrid Login")
         icon = QtGui.QIcon(resources.get_openpype_icon_filepath())
         self.setWindowIcon(icon)
 
@@ -44,7 +44,7 @@ class SgLoginDialog(QtWidgets.QDialog):
         server_url = self.addon.get_sg_url()
 
         if not server_url:
-            server_url = "No Shotgrid Server set in Ayon Settings."
+            server_url = "No Shotgrid Server set in AYON Settings."
 
         sg_server_url_label = QtWidgets.QLabel(
             "Please provide the credentials to log in into the "

--- a/client/ayon_shotgrid/tray/shotgrid_tray.py
+++ b/client/ayon_shotgrid/tray/shotgrid_tray.py
@@ -7,7 +7,7 @@ from ayon_shotgrid.tray.sg_login_dialog import SgLoginDialog
 
 
 class ShotgridTrayWrapper:
-    """ Shotgrid menu entry for the Ayon tray.
+    """ Shotgrid menu entry for the AYON tray.
 
     Displays the Shotgrid URL specified in the Server Addon Settings and
     allows the person to set a username to be used with the API.
@@ -21,7 +21,7 @@ class ShotgridTrayWrapper:
         server_url = self.addon.get_sg_url()
 
         if not server_url:
-            server_url = "No Shotgrid Server set in Ayon Settings."
+            server_url = "No Shotgrid Server set in AYON Settings."
 
         self.sg_server_label = QtWidgets.QAction("Server: {0}".format(
                 server_url
@@ -45,13 +45,13 @@ class ShotgridTrayWrapper:
         self.sg_username_dialog.raise_()
 
     def tray_menu(self, tray_menu):
-        """Add Shotgrid Submenu to Ayon tray.
+        """Add Shotgrid Submenu to AYON tray.
 
         A non-actionable action displays the Shotgrid URL and the other
         action allows the person to set and check their Shotgrid username.
 
         Args:
-            tray_menu (QtWidgets.QMenu): The Ayon Tray menu.
+            tray_menu (QtWidgets.QMenu): The AYON Tray menu.
         """
         shotgrid_tray_menu = QtWidgets.QMenu("Shotgrid", tray_menu)
         shotgrid_tray_menu.addAction(self.sg_server_label)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -27,7 +27,7 @@ class ShotgridAddon(BaseServerAddon):
             self.request_server_restart()
 
     async def create_shotgrid_attributes(self) -> bool:
-        """Make sure Ayon has the `shotgridId` and `shotgridPath` attributes.
+        """Make sure AYON has the `shotgridId` and `shotgridPath` attributes.
 
         Returns:
             bool: 'True' if an attribute was created or updated.

--- a/services/Makefile
+++ b/services/Makefile
@@ -4,7 +4,7 @@ SERVICE = $(error Please specify the service to build with 'SERVICE', for exampl
 
 default:
 	@echo ""
-	@echo "Ayon Shotgrid $(ADDON_VERSION) Service Builder"
+	@echo "AYON Shotgrid $(ADDON_VERSION) Service Builder"
 	@echo ""
 	@echo "Usage: make SERVICE=[service-name] [target]"
 	@echo ""

--- a/services/leecher/README.md
+++ b/services/leecher/README.md
@@ -1,6 +1,6 @@
 # Shotgrid Leecher
 
-The Shotgrid leecher depends on the [Shotgrid Addon for Ayon](https://github.com/ynput/ayon-shotgrid-addon) since it expects certain settings provided once the addon is installed in the server.
+The Shotgrid leecher depends on the [Shotgrid Addon for AYON](https://github.com/ynput/ayon-shotgrid-addon) since it expects certain settings provided once the addon is installed in the server.
 
 To get started, create a copy of the `sample_env` file and rename it to `.env` and set the values acordingly, after that you can run the service by issuing:
 ```sh

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -1,8 +1,8 @@
 """
-A Shotgrid Events listener leecher for Ayon.
+A Shotgrid Events listener leecher for AYON.
 
 This service will continually run and query the EventLogEntry table from
-Shotgrid and converts them to Ayon events, and can be configured from the Ayon
+Shotgrid and converts them to AYON events, and can be configured from the AYON
 Addon settings page.
 """
 import sys
@@ -45,7 +45,7 @@ class ShotgridListener:
     log = get_logger(__file__)
 
     def __init__(self):
-        """Ensure both Ayon and Shotgrid connections are available.
+        """Ensure both AYON and Shotgrid connections are available.
 
         Set up common needed attributes and handle shotgrid connection
         closure via signal handlers.
@@ -232,7 +232,7 @@ class ShotgridListener:
         """Main loop querying the Shotgrid database for new events
 
         Since Shotgrid does not have an event hub per se, we need to query
-        the "EventLogEntry table and send these as Ayon events for processing.
+        the "EventLogEntry table and send these as AYON events for processing.
 
         We try to continue from the last Event processed by the leecher, if
         none is found we start at the moment in time.
@@ -349,7 +349,7 @@ class ShotgridListener:
     def send_shotgrid_event_to_ayon(
         self, payload: dict[str, Any], sg_projects_by_id: dict[str, Any]
     ):
-        """Send the Shotgrid event as an Ayon event.
+        """Send the Shotgrid event as an AYON event.
 
         Args:
             payload (dict): The Event data.
@@ -400,7 +400,7 @@ class ShotgridListener:
             },
         )
 
-        self.log.info("Dispatched Ayon event with payload:", payload)
+        self.log.info("Dispatched AYON event with payload:", payload)
 
 
 def service_main():

--- a/services/leecher/pyproject.toml
+++ b/services/leecher/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "shotgrid-leecher"
 version = "0.4.6-dev.1"
-description = "Shotgrid Integration for Ayon"
+description = "Shotgrid Integration for AYON"
 authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 
 [tool.poetry.dependencies]

--- a/services/manage.ps1
+++ b/services/manage.ps1
@@ -34,7 +34,7 @@ function Get-ServiceImage {
 # Show help message with details on how to use this script
 function Show-Help {
     Write-Host ""
-    Write-Host "Ayon Shotgrid $AddonVersion Service Builder"
+    Write-Host "AYON Shotgrid $AddonVersion Service Builder"
     Write-Host ""
     Write-Host "Usage: .\manage.ps1 [target] -Service [service-name]"
     Write-Host ""

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -1,7 +1,7 @@
 """
-A Shotgrid Events listener processor for Ayon.
+A Shotgrid Events listener processor for AYON.
 
-This service will continually run and query the Ayon Events Server in orther to
+This service will continually run and query the AYON Events Server in orther to
 entroll the events of topic `shotgrid.leech` to perform processing of Shotgrid
 related events.
 """

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "shotgrid-processor"
 version = "0.4.6-dev.1"
-description = "Shotgrid Integration for Ayon"
+description = "Shotgrid Integration for AYON"
 authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 
 [tool.poetry.dependencies]

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -1,6 +1,6 @@
 """ Influenced by the `ayon_api.EntityHub` the `AyonShotgridHub` is a class
 that provided a valid Project name and code, will perform all the necessary
-checks and provide methods to keep an Ayon and Shotgrid project in sync.
+checks and provide methods to keep an AYON and Shotgrid project in sync.
 """
 import re
 
@@ -400,7 +400,7 @@ class AyonShotgridHub:
                 attrib_key = next(iter(ayon_event["payload"]["newValue"]))
                 if attrib_key not in self.custom_attribs_map:
                     self.log.warning(
-                        f"Updating attribute '{attrib_key}' from Ayon to SG "
+                        f"Updating attribute '{attrib_key}' from AYON to SG "
                         f"not supported: {self.custom_attribs_map}."
                     )
                     return

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -385,7 +385,7 @@ def _create_new_entity(
         ):
             data[sg_parent_field] = sg_parent_entity
 
-    # Fill up data with any extra attributes from Ayon we want to sync to SG
+    # Fill up data with any extra attributes from AYON we want to sync to SG
     data |= get_sg_custom_attributes_data(
         sg_session,
         ay_entity.attribs.to_dict(),

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -166,7 +166,7 @@ def match_shotgrid_hierarchy_in_ayon(
                 CUST_FIELD_CODE_ID: ay_entity.id,
                 CUST_FIELD_CODE_SYNC: sg_entity_sync_status
             }
-            # Update Shotgrid entity with Ayon ID and sync status
+            # Update Shotgrid entity with AYON ID and sync status
             sg_session.update(
                 sg_ay_dict["attribs"][SHOTGRID_TYPE_ATTRIB],
                 sg_entity_id,
@@ -216,7 +216,7 @@ def match_shotgrid_hierarchy_in_ayon(
 
     entity_hub.commit_changes()
 
-    # Update Shotgrid project with Ayon ID and sync status
+    # Update Shotgrid project with AYON ID and sync status
     sg_session.update(
         "Project",
         sg_project["id"],
@@ -243,8 +243,8 @@ def _create_new_entity(
 
     Args:
         entity_hub (ayon_api.EntityHub): The project's entity hub.
-        parent_entity: Ayon parent entity.
-        sg_ay_dict (dict): Ayon ShotGrid entity to create.
+        parent_entity: AYON parent entity.
+        sg_ay_dict (dict): AYON ShotGrid entity to create.
     """
     if sg_ay_dict["type"].lower() == "task":
         # only create if parent_entity type is not project

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
@@ -17,9 +17,9 @@ from utils import (
     get_sg_custom_attributes_data
 )
 from constants import (
-    CUST_FIELD_CODE_ID,  # Shotgrid Field for the Ayon ID.
-    SHOTGRID_ID_ATTRIB,  # Ayon Entity Attribute.
-    SHOTGRID_TYPE_ATTRIB,  # Ayon Entity Attribute.
+    CUST_FIELD_CODE_ID,  # Shotgrid Field for the AYON ID.
+    SHOTGRID_ID_ATTRIB,  # AYON Entity Attribute.
+    SHOTGRID_TYPE_ATTRIB,  # AYON Entity Attribute.
 )
 
 from utils import get_logger
@@ -45,7 +45,7 @@ def create_sg_entity_from_ayon_event(
         sg_project (dict): The Shotgrid project.
         sg_enabled_entities (list): List of Shotgrid entities to be enabled.
         custom_attribs_map (dict): Dictionary that maps a list of attribute names from
-            Ayon to Shotgrid.
+            AYON to Shotgrid.
 
     Returns:
         ay_entity (ayon_api.entity_hub.EntityHub.Entity): The newly
@@ -289,7 +289,7 @@ def remove_sg_entity_from_ayon_event(
 
     if not sg_entity:
         log.warning(
-            f"Unable to find Ayon entity with id '{ay_id}' in Shotgrid.")
+            f"Unable to find AYON entity with id '{ay_id}' in Shotgrid.")
         return
 
     sg_id = sg_entity["id"]
@@ -421,7 +421,7 @@ def _create_sg_entity(
             CUST_FIELD_CODE_ID: ay_entity.id,
         }
 
-    # Fill up data with any extra attributes from Ayon we want to sync to SG
+    # Fill up data with any extra attributes from AYON we want to sync to SG
     data.update(get_sg_custom_attributes_data(
         sg_session,
         ay_entity.attribs.to_dict(),

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -12,7 +12,7 @@ The updates come through `meta` dictionaries such as:
     "retirement_date": "2023-03-31 15:26:16 UTC"
 }
 
-And most of the times it fetches the ShotGrid entity as an Ayon dict like:
+And most of the times it fetches the ShotGrid entity as an AYON dict like:
 {
     "label": label,
     "name": name,
@@ -34,9 +34,9 @@ from utils import (
     update_ay_entity_custom_attributes,
 )
 from constants import (
-    CUST_FIELD_CODE_ID,  # ShotGrid Field for the Ayon ID.
-    SHOTGRID_ID_ATTRIB,  # Ayon Entity Attribute.
-    SHOTGRID_TYPE_ATTRIB,  # Ayon Entity Attribute.
+    CUST_FIELD_CODE_ID,  # ShotGrid Field for the AYON ID.
+    SHOTGRID_ID_ATTRIB,  # AYON Entity Attribute.
+    SHOTGRID_TYPE_ATTRIB,  # AYON Entity Attribute.
     SHOTGRID_REMOVED_VALUE,  # Value for removed entities.
     SG_RESTRICTED_ATTR_FIELDS,
 )
@@ -66,7 +66,7 @@ def create_ay_entity_from_sg_event(
         sg_enabled_entities (list[str]): List of entity strings enabled.
         project_code_field (str): The Shotgrid project code field.
         custom_attribs_map (Optional[dict]): A dictionary that maps ShotGrid
-            attributes to Ayon attributes.
+            attributes to AyonAYON attributes.
 
     Returns:
         ay_entity (ayon_api.entity_hub.EntityHub.Entity): The newly
@@ -109,10 +109,10 @@ def create_ay_entity_from_sg_event(
 
         if ay_entity:
             log.debug("ShotGrid Entity exists in AYON.")
-            # Ensure Ayon Entity has the correct ShotGrid ID
+            # Ensure AYON Entity has the correct ShotGrid ID
             ayon_entity_sg_id = str(
                 ay_entity.attribs.get_attribute(SHOTGRID_ID_ATTRIB).value)
-            # Ensure Ayon Entity has the correct Shotgrid ID
+            # Ensure AYON Entity has the correct Shotgrid ID
             ay_shotgrid_id = str(
               sg_ay_dict["attribs"].get(SHOTGRID_ID_ATTRIB, ""))
             if ayon_entity_sg_id != ay_shotgrid_id:
@@ -173,7 +173,7 @@ def create_ay_entity_from_sg_event(
         # This really should be an edge  ase, since any parent event would
         # happen before this... but hey
         raise ValueError(
-            "Parent does not exist in Ayon, try doing a Project Sync.")
+            "Parent does not exist in AYON, try doing a Project Sync.")
 
     if sg_ay_dict["type"].lower() == "task":
         ay_entity = ayon_entity_hub.add_new_task(
@@ -229,7 +229,7 @@ def update_ayon_entity_from_sg_event(
     project_code_field: str,
     custom_attribs_map: Optional[Dict[str, str]] = None
 ):
-    """Try to update an entity in Ayon.
+    """Try to update an entity in AYON.
 
     Args:
         sg_event (dict): The `meta` key from a ShotGrid Event.
@@ -239,7 +239,7 @@ def update_ayon_entity_from_sg_event(
         sg_enabled_entities (list[str]): List of entity strings enabled.
         project_code_field (str): The ShotGrid project code field.
         custom_attribs_map (dict): A dictionary that maps ShotGrid
-            attributes to Ayon attributes.
+            attributes to AYON attributes.
 
     Returns:
         ay_entity (ayon_api.entity_hub.EntityHub.Entity): The modified entity.
@@ -260,7 +260,7 @@ def update_ayon_entity_from_sg_event(
         )
         return
 
-    # if the entity does not have an Ayon ID, try to create it
+    # if the entity does not have an AYON ID, try to create it
     # and no need to update
     if not sg_ay_dict["data"].get(CUST_FIELD_CODE_ID):
         log.debug(f"Creating AYON Entity: {sg_ay_dict}")
@@ -293,13 +293,13 @@ def update_ayon_entity_from_sg_event(
     ):
         raise ValueError("Entity is immutable, aborting...")
 
-    # Ensure Ayon Entity has the correct ShotGrid ID
+    # Ensure AYON Entity has the correct ShotGrid ID
     ayon_entity_sg_id = str(
         ay_entity.attribs.get_attribute(SHOTGRID_ID_ATTRIB).value)
     sg_entity_sg_id = str(
         sg_ay_dict["attribs"].get(SHOTGRID_ID_ATTRIB, "")
     )
-    log.debug(f"Updating Ayon Entity: {ay_entity.name}")
+    log.debug(f"Updating AYON Entity: {ay_entity.name}")
 
     if ayon_entity_sg_id != sg_entity_sg_id:
         raise ValueError("Mismatching ShotGrid IDs, aborting...")
@@ -332,13 +332,13 @@ def remove_ayon_entity_from_sg_event(
     ayon_entity_hub: ayon_api.entity_hub.EntityHub,
     project_code_field: str,
 ):
-    """Try to remove an entity in Ayon.
+    """Try to remove an entity in AYON.
 
     Args:
         sg_event (dict): The `meta` key from a ShotGrid Event.
         sg_session (shotgun_api3.Shotgun): The ShotGrid API session.
         ayon_entity_hub (ayon_api.entity_hub.EntityHub): The AYON EntityHub.
-        project_code_field (str): The ShotGrid field that contains the Ayon ID.
+        project_code_field (str): The ShotGrid field that contains the AYON ID.
     """
     # for now we are ignoring Task type entities
     # TODO: Handle Task entities
@@ -376,7 +376,7 @@ def remove_ayon_entity_from_sg_event(
 
     if not sg_ay_dict["data"].get(CUST_FIELD_CODE_ID):
         log.warning(
-            "Entity does not have an Ayon ID, aborting..."
+            "Entity does not have an AYON ID, aborting..."
         )
         return
 

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -97,8 +97,8 @@ def _sg_to_ay_dict(
 ) -> dict:
     """Morph a ShotGrid entity dict into an ayon-api Entity Hub compatible one.
 
-    Create a dictionary that follows the Ayon Entity Hub schema and handle edge
-    cases so it's ready for Ayon consumption.
+    Create a dictionary that follows the AYON Entity Hub schema and handle edge
+    cases so it's ready for AYON consumption.
 
     Folders: https://github.com/ynput/ayon-python-api/blob/30d702618b58676c3708f09f131a0974a92e1002/ayon_api/entity_hub.py#L2397  # noqa
     Tasks: https://github.com/ynput/ayon-python-api/blob/30d702618b58676c3708f09f131a0974a92e1002/ayon_api/entity_hub.py#L2579  # noqa
@@ -149,7 +149,7 @@ def _sg_to_ay_dict(
         "data": {
             # We store the ShotGrid ID and the Sync status in the data
             # dictionary so we can easily access them when needed
-            # And avoid any conflicts with the Ayon attributes we only set
+            # And avoid any conflicts with the AYON attributes we only set
             # sync status to "Failed" if the ID is not set
             CUST_FIELD_CODE_SYNC: (
                 sg_entity.get(CUST_FIELD_CODE_SYNC)
@@ -183,7 +183,7 @@ def create_ay_fields_in_sg_entities(
     custom_attribs_map: dict,
     custom_attribs_types: dict
 ):
-    """Create Ayon fields in ShotGrid entities.
+    """Create AYON fields in ShotGrid entities.
 
     Some fields need to exist in the ShotGrid Entities, mainly the `sg_ayon_id`
     and `sg_ayon_sync_status` for the correct operation of the handlers.
@@ -213,7 +213,7 @@ def create_ay_fields_in_sg_entities(
             CUST_FIELD_CODE_SYNC,
             field_properties={
                 "name": "Ayon Sync Status",
-                "description": "The Synchronization status with Ayon.",
+                "description": "The Synchronization status with AYON.",
                 "valid_values": ["Synced", "Failed", "Skipped"],
             }
         )
@@ -233,7 +233,7 @@ def create_ay_custom_attribs_in_sg_entity(
     custom_attribs_map: dict,
     custom_attribs_types: dict
 ):
-    """Create Ayon custom attributes in ShotGrid entities.
+    """Create AYON custom attributes in ShotGrid entities.
 
     Args:
         sg_session (shotgun_api3.Shotgun): Instance of a ShotGrid API Session.
@@ -282,7 +282,7 @@ def create_ay_fields_in_sg_project(
     custom_attribs_map: dict,
     custom_attribs_types: dict
 ):
-    """Create Ayon Project fields in ShotGrid.
+    """Create AYON Project fields in ShotGrid.
 
     This will create Project Unique attributes into ShotGrid.
 
@@ -343,7 +343,7 @@ def create_sg_entities_in_ay(
         sg_enabled_entities (list): The enabled entities.
     """
 
-    # Types of SG entities to ignore as Ayon folders
+    # Types of SG entities to ignore as AYON folders
     ignored_folder_types = {"task", "version"}
 
     # Find ShotGrid Entities that are to be treated as folders
@@ -403,7 +403,7 @@ def create_asset_category(entity_hub, parent_entity, sg_ay_dict):
     Args:
         entity_hub (ayon_api.EntityHub): The project's entity hub.
         parent_entity: AYON parent entity.
-        sg_ay_dict (dict): The ShotGrid entity ready for Ayon consumption.
+        sg_ay_dict (dict): The ShotGrid entity ready for AYON consumption.
     """
     asset_category = sg_ay_dict["data"]["sg_asset_type"]
     # asset category entity name
@@ -440,8 +440,8 @@ def get_asset_category(entity_hub, parent_entity, sg_ay_dict):
 
     Args:
         entity_hub (ayon_api.EntityHub): The project's entity hub.
-        parent_entity: Ayon parent entity.
-        sg_ay_dict (dict): The ShotGrid entity ready for Ayon consumption.
+        parent_entity: AYON parent entity.
+        sg_ay_dict (dict): The ShotGrid entity ready for AYON consumption.
 
     """
     # just in case the asset type doesn't exist yet
@@ -694,7 +694,7 @@ def get_sg_entity_as_ay_dict(
     extra_fields: Optional[list] = None,
     retired_only: Optional[bool] = False,
 ) -> dict:
-    """Get a ShotGrid entity, and morph it to an Ayon compatible one.
+    """Get a ShotGrid entity, and morph it to an AYON compatible one.
 
     Args:
         sg_session (shotgun_api3.Shotgun): Shotgun Session object.
@@ -706,7 +706,7 @@ def get_sg_entity_as_ay_dict(
         extra_fields (Optional[list]): List of optional fields to query.
         retired_only (bool): Whether to return only retired entities.
     Returns:
-        new_entity (dict): The ShotGrid entity ready for Ayon consumption.
+        new_entity (dict): The ShotGrid entity ready for AYON consumption.
     """
     query_fields = list(SG_COMMON_ENTITY_FIELDS)
     if extra_fields and isinstance(extra_fields, list):
@@ -784,7 +784,7 @@ def get_sg_entity_parent_field(
 
 
 def get_sg_missing_ay_attributes(sg_session: shotgun_api3.Shotgun):
-    """ Ensure all the Ayon required fields are present in ShotGrid.
+    """ Ensure all the AYON required fields are present in ShotGrid.
 
     Args:
         sg_session (shotgun_api3.Shotgun): Instance of a ShotGrid API Session.
@@ -953,7 +953,7 @@ def get_sg_statuses(
     """
     # If given an entity type, we filter out the statuses by just the ones
     # supported by that entity
-    # NOTE: this is a limitation in Ayon as the statuses are global and not
+    # NOTE: this is a limitation in AYON as the statuses are global and not
     # per entity
     if sg_entity_type:
         if sg_entity_type == "Project":
@@ -1075,7 +1075,7 @@ def update_ay_entity_custom_attributes(
     custom_attribs_map: dict,
     values_to_update: Optional[list] = None,
 ):
-    """Update Ayon entity custom attributes from ShotGrid dictionary"""
+    """Update AYON entity custom attributes from ShotGrid dictionary"""
     for ay_attrib, _ in custom_attribs_map.items():
         if values_to_update and ay_attrib not in values_to_update:
             continue

--- a/services/transmitter/pyproject.toml
+++ b/services/transmitter/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "shotgrid-transmitter"
 version = "0.4.6-dev.1"
-description = "Shotgrid Integration for Ayon"
+description = "Shotgrid Integration for AYON"
 authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 
 [tool.poetry.dependencies]

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -1,7 +1,7 @@
 """
 A AYON Events listener to push changes to Shotgrid.
 
-This service will continually run and query the Ayon Events Server in order to
+This service will continually run and query the AYON Events Server in order to
 enroll the events of topic `entity.folder` and `entity.task` when any of the
 two are `created`, `renamed` or `deleted`.
 """
@@ -23,7 +23,7 @@ class ShotgridTransmitter:
     _sg: shotgun_api3.Shotgun = None
 
     def __init__(self):
-        """ Ensure both Ayon and Shotgrid connections are available.
+        """ Ensure both AYON and Shotgrid connections are available.
 
         Set up common needed attributes and handle shotgrid connection
         closure via signal handlers.


### PR DESCRIPTION
## Changelog Description
Use 'AYON' over 'Ayon' in logs and docstrings.

## Additional info
None of made changes should affect code logic. There were not done change that would affect production (e.g. attribute names).

## Testing notes:
1. Validate changed lines.
