### PR TITLE
Chore: Fix usage of missing function

### DIFF
--- a/client/ayon_shotgrid/tray/sg_login_dialog.py
+++ b/client/ayon_shotgrid/tray/sg_login_dialog.py
@@ -21,7 +21,7 @@ class SgLoginDialog(QtWidgets.QDialog):
         self.login_type = self.addon.get_client_login_type()
 
         self.setWindowTitle("AYON - Shotgrid Login")
-        icon = QtGui.QIcon(resources.get_openpype_icon_filepath())
+        icon = QtGui.QIcon(resources.get_ayon_icon_filepath())
         self.setWindowIcon(icon)
 
         self.setWindowFlags(


### PR DESCRIPTION
## Changelog Description
Use `get_ayon_icon_filepath` instead of `get_openpype_icon_filepath`.


## Additional info
Function `get_openpype_icon_filepath` was removed in ayon-core 1.0.0 .


## Testing notes:
1. Validate changes.
