### PR TITLE
Remodeling settings for Re-parenting of SG entity types for AYON hierarchy

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -127,15 +127,6 @@ class AttributesMappingModel(BaseSettingsModel):
         enum_resolver=default_shotgrid_entities
     )
 
-
-class FolderLocationsModel(BaseSettingsModel):
-    """AYON folders to store separate of SG types"""
-    asset_folder: str = SettingsField(title="Assets", default="assets")
-    sequence_folder: str = SettingsField(title="Sequences",
-                                         default="sequences")
-    shot_folder: str = SettingsField(title="Shots", default="shots")
-
-
 class FolderReparentingParentsModel(BaseSettingsModel):
     sg_entity_type: str = SettingsField(
         "Asset",
@@ -231,14 +222,6 @@ class ShotgridCompatibilitySettings(BaseSettingsModel):
         ),
     )
 
-    folder_locations: FolderLocationsModel = SettingsField(
-        title="Folder locations",
-        default_factory=FolderLocationsModel,
-        description=(
-            "Locations of AYON folders matching to SG types."
-            "Eg. where SG assets will be stored, where SG shots and sequences."
-        ),
-    )
     folder_parenting: FolderReparentingModel = SettingsField(
         title="Folder re-parenting",
         default_factory=FolderReparentingModel,

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -40,7 +40,6 @@ def default_shotgrid_reparenting_entities():
         "Episode",
         "Sequence",
         "Shot",
-        "AssetCategory",
         "Asset",
     ]
 
@@ -127,42 +126,27 @@ class AttributesMappingModel(BaseSettingsModel):
         enum_resolver=default_shotgrid_entities
     )
 
+
 class FolderReparentingParentsModel(BaseSettingsModel):
-    sg_entity_type: str = SettingsField(
-        "Asset",
-        title="ShotGrid Entity Type",
-        enum_resolver=(
-            lambda: default_shotgrid_reparenting_entities() + ["< None >"]
-        ),
-        description=(
-            "Type of the ShotGrid entity to parent in AYON. "
-            "' < None > ' means no SG type and can be used just as folder."
-        ),
-    )
     folder_type: str = SettingsField(
         "asset",
-        title="Parent Folder Type",
+        title="Parent Ayon Folder Type",
         enum_resolver=folder_types_enum,
         description="Type of the parent folder in AYON",
     )
     folder_name: str = SettingsField(
         "assets",
-        title="Parent Folder Name",
-        description="Name of the parent folder in AYON",
+        title="Parent Ayon Folder Name",
+        description=(
+            "Name of the parent folder in AYON. Anatomy presets can be used."
+            "`sg_` prefix can be used to refer to ShotGrid entities. Example: "
+            "`{sg_asset[type]}` will be replaced with the ShotGrid Asset Type."
+        ),
     )
 
 
 class FolderReparentingPresetsModel(BaseSettingsModel):
 
-    reparenting_type: str = SettingsField(
-        "root_relocate",
-        title="Re-parenting Type",
-        enum_resolver=lambda: [
-            {"value": "root_relocate", "label": "Root relocation"},
-            {"value": "type_grouping", "label": "Type grouping"},
-        ],
-        description="Type of the parenting",
-    )
     filter_by_sg_entity_type: str = SettingsField(
         "Asset",
         title="Filter by ShotGrid Entity Type",
@@ -181,8 +165,8 @@ class FolderReparentingPresetsModel(BaseSettingsModel):
     )
 
 
-class FolderReparentingModel(BaseSettingsModel):
-    """Re-parent folders for AYON folders matching to SG types"""
+class FolderReparentingRelocateModel(BaseSettingsModel):
+    """Re-parent folders with Root relocation"""
     enabled: bool = SettingsField(
         False,
         title="Enabled",
@@ -198,6 +182,36 @@ class FolderReparentingModel(BaseSettingsModel):
         ),
     )
 
+
+class FolderReparentingTypeGroupingModel(BaseSettingsModel):
+    """Re-parent folders with Type grouping"""
+    enabled: bool = SettingsField(
+        False,
+        title="Enabled",
+        description="Enable or disable the re-parenting",
+    )
+
+    presets: list[FolderReparentingPresetsModel] = SettingsField(
+        title="Presets",
+        default_factory=list,
+        description=(
+            "List of presets for re-parenting. "
+            "If empty default behavior will be used."
+        ),
+    )
+
+
+class FolderReparentingModel(BaseSettingsModel):
+
+    root_relocate: FolderReparentingRelocateModel = SettingsField(
+        default_factory=FolderReparentingRelocateModel,
+        title="Root relocation",
+    )
+
+    type_grouping: FolderReparentingTypeGroupingModel = SettingsField(
+        default_factory=FolderReparentingTypeGroupingModel,
+        title="Type grouping",
+    )
 
 class ShotgridCompatibilitySettings(BaseSettingsModel):
     """ Settings to define relationships between ShotGrid and AYON.

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -424,6 +424,9 @@ def get_asset_category(entity_hub, parent_entity, sg_ay_dict, addon_settings):
     asset_category_name = slugify_string(
         sg_ay_dict["data"]["sg_asset_type"]).lower()
 
+    # TODO: this needs to be changed to implement the new re parenting
+    #  structure from `folder_parenting` presets
+    # addon_settings["compatibility_settings"]["folder_parenting"]
     folder_path = (addon_settings["compatibility_settings"]
                                  ["folder_locations"]
                                  ["asset_folder"])
@@ -453,6 +456,9 @@ def get_sequence_category(entity_hub, parent_entity, sg_ay_dict, addon_settings)
         sg_ay_dict (dict): The ShotGrid entity ready for AYON consumption.
 
     """
+    # TODO: this needs to be changed to implement the new re parenting
+    #  structure from `folder_parenting` presets
+    # addon_settings["compatibility_settings"]["folder_parenting"]
     folder_path = (addon_settings["compatibility_settings"]
                                  ["folder_locations"]
                                  ["sequence_folder"])
@@ -474,6 +480,9 @@ def get_shot_category(entity_hub, parent_entity, sg_ay_dict, addon_settings):
         sg_ay_dict (dict): The ShotGrid entity ready for Ayon consumption.
 
     """
+    # TODO: this needs to be changed to implement the new re parenting
+    #  structure from `folder_parenting` presets
+    # addon_settings["compatibility_settings"]["folder_parenting"]
     folder_path = (addon_settings["compatibility_settings"]
                                  ["folder_locations"]
                                  ["shot_folder"])


### PR DESCRIPTION
This is just a mockup the settings for presentation of an idea for new settings, which could be used in #129 

Here are some use cases:
### 1. Relocate root folder for SG Asset Entity types

```
├── build 
│   └── assets 
│       └── Prop 
│           ├── AssetProp01
│           └── AssetProp02
│       └── Character
│           ├── AsseCharacter01
│           └── AssetCharacter02
│       └── Environment
│           ├── AssetEnvironment01
│           └── AssetEnvironment2
```
![image](https://github.com/user-attachments/assets/e5c954f3-52a9-4c6a-b562-8e936727ea2e)

### 2. Type grouping for Sequences and Shots
```
├── sequences
|    ├── SQ_010
|    └── SQ_020
├── shots
|    ├── SH_0010
|    └── SH_0020
```
![image](https://github.com/user-attachments/assets/72aaad14-db28-4877-9090-a3a876ba57d4)


## Main Features of the Settings:
1. Each feature has its own category that can be activated. This helps in better validating conflicting settings configurations. For example, "Type Grouping" should not be activated if "Root Relocation Presets" is activated, and vice versa.
2. The parent name input supports Anatomy formatting tokens. Proper documentation is needed, so users should have access to a cheat sheet.