### PR TITLE
Fill environment variables for farm jobs

### DIFF
--- a/client/ayon_shotgrid/plugins/publish/collect_farm_env_variables.py
+++ b/client/ayon_shotgrid/plugins/publish/collect_farm_env_variables.py
@@ -1,0 +1,26 @@
+import os
+
+import pyblish.api
+
+try:
+    from ayon_core.pipeline.publish import FARM_JOB_ENV_DATA_KEY
+except ImportError:
+    # NOTE Can be removed when ayon-core >= 1.0.10 is required in package.py
+    FARM_JOB_ENV_DATA_KEY = "farmJobEnv"
+
+
+class CollectShotgridJobEnvVars(pyblish.api.ContextPlugin):
+    """Collect set of environment variables to submit with deadline jobs"""
+    order = pyblish.api.CollectorOrder - 0.45
+    label = "Collect Shotgrid farm environment variables"
+    targets = ["local"]
+
+    def process(self, context):
+        env = context.data.setdefault(FARM_JOB_ENV_DATA_KEY, {})
+        for key in [
+            "AYON_SG_USERNAME",
+        ]:
+            value = os.getenv(key)
+            if value:
+                self.log.debug(f"Setting job env: {key}: {value}")
+                env[key] = value


### PR DESCRIPTION
## Changelog Description
Fill environment variables for farm in publish plugins.

## Additional review information
Move control to collect shotgrid environment variables, needed for farm jobs, to shotgrid addon.

## Testing notes:
1. At this moment probably nothing changed because deadline has to stop filling the key.

Resolves https://github.com/ynput/ayon-shotgrid/issues/149
