### PR TITLE
Transmitter: Added missing 'arrow' dependency

### DIFF
--- a/services/transmitter/pyproject.toml
+++ b/services/transmitter/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
 appdirs = "^1.4"
 python = ">=3.10,<4.0"
 pydantic = "^1.10.2"
+arrow = "*"
 ayon-python-api = "^1.0.0"
 shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }
 


### PR DESCRIPTION
## Changelog Description
Added `arrow` dependency to transmitter service.

## Testing notes:
1. Transmitter service can actually do stuff.
