### PR TITLE
Avoid to repopulate all ids and type on AYON->SG sync

### DIFF
--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -225,20 +225,19 @@ def match_ayon_hierarchy_in_shotgrid(
             sg_ay_dicts[sg_entity_id] = sg_ay_dict
             sg_ay_dicts_parents[sg_parent_entity["id"]].add(sg_entity_id)
 
+            # add new Shotgrid ID and type to existing AYON entity
+            ay_entity.attribs.set(
+                SHOTGRID_ID_ATTRIB,
+                sg_entity_id
+            )
+            ay_entity.attribs.set(
+                SHOTGRID_TYPE_ATTRIB,
+                sg_ay_dict["attribs"][SHOTGRID_TYPE_ATTRIB]
+            )
+
         if not sg_ay_dict:
             log.warning(f"AYON entity {ay_entity} not found in SG, ignoring it")
             continue
-
-        # add Shotgrid ID and type to AYON entity
-        ay_entity.attribs.set(
-            SHOTGRID_ID_ATTRIB,
-            sg_entity_id
-        )
-
-        ay_entity.attribs.set(
-            SHOTGRID_TYPE_ATTRIB,
-            sg_ay_dict["attribs"][SHOTGRID_TYPE_ATTRIB]
-        )
 
         # add processed entity to the set for duplicity tracking
         processed_ids.add(sg_entity_id)


### PR DESCRIPTION
## Changelog Description

Ensure that triggering `SG -> AYON` manually does not re-populate all of the `shotgridId` and `shotgridType` for AYON entities.

## Testing notes:

1. Ensure this new code is running as a service
2. Have an existing AYON project already in syncing with SG
3. In AYON, create a new Task that would sync with SG
4. Click `AYON -> SG` button in the settings panel
5. Ensure newly added Task get properly set with a `shotgridId` attribute
