### PR TITLE
Fix settings field description for comment syncing

### DIFF
--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -288,7 +288,7 @@ class ShotgridTransmitter:
         response = ayon_api.dispatch_event(
             SHOTGRID_COMMENTS_TOPIC,
             description=(
-                "Synchronizing comments from ftrack to AYON."
+                "Synchronizing comments from AYON to SG."
             ),
             summary=None,
             payload={},


### PR DESCRIPTION
Sync loop in transmitter is from AYON to SG (there is no `comment.updated` event topic on AYON side.)