### PR TITLE
AY-7631 Fix Flow notes from Version not parented properly to AYON.

### DIFF
--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -497,18 +497,18 @@ class AyonShotgridHub:
                     sg_user_id_by_user_name, ayon_username)
 
                 if sg_user_id < 0:
-                    self.log.warning(
-                        f"Author {ayon_username} is not "
-                        "synchronized to SG, skipping comment"
+                    self.log.debug(
+                        f"Author {ayon_username} is not synchronized "
+                        "to SG, comment will be left unassigned."
                     )
-                    continue
+                    sg_user_id = None
 
                 self._create_sg_note(
                     self.project_name,
                     entity_dict,
                     activity,
-                    sg_user_id,
-                    sg_user_id_by_user_name
+                    sg_user_id_by_user_name,
+                    author_sg_id=sg_user_id,
                 )
             else:
                 sg_update_data = {}
@@ -575,8 +575,8 @@ class AyonShotgridHub:
         project_name,
         entity_dict,
         activity,
-        author_sg_id,
-        sg_user_id_by_user_name
+        sg_user_id_by_user_name,
+        author_sg_id=None,
     ):
         """Create a new note in ShotGrid (SG) and update the activity data.
 
@@ -590,9 +590,9 @@ class AyonShotgridHub:
                 entity (folder, task, version) to which the note is linked.
             activity (dict): Activity data containing details about the comment,
                 including the author, content, and activity ID.
-            author_sg_id (int): The SG user ID of the author of the comment.
             sg_user_id_by_user_name (dict): A mapping of AYON usernames to
                 their corresponding SG user IDs.
+            author_sg_id (int): (Optional) The SG user ID of the author of the comment.
         """
         if not self._sg_project:
             self.log.warning(
@@ -609,9 +609,11 @@ class AyonShotgridHub:
             "note_links": note_links,
             "subject": content[:50],
             "content": content,
-            "user": {"type": "HumanUser", "id": author_sg_id},
             "addressings_to": addressings_to
         }
+
+        if author_sg_id:
+            data["user"] = {"type": "HumanUser", "id": author_sg_id}
 
         # Create the note
         result = self._sg.create("Note", data)

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -102,6 +102,12 @@ def create_ay_entity_from_sg_event(
         custom_attribs_map=custom_attribs_map,
         extra_fields=extra_fields,
     )
+
+    if sg_ay_dict["type"].lower() == "comment":
+        # SG note as AYON comment creation is
+        # handled by update_ayon_entity_from_sg_event
+        return
+
     log.debug(f"ShotGrid Entity as AYON dict: {sg_ay_dict}")
     if not sg_ay_dict:
         log.warning(
@@ -373,6 +379,7 @@ def update_ayon_entity_from_sg_event(
         return
 
     if sg_ay_dict["type"].lower() == "comment":
+        import pdb ; pdb.set_trace()
         handle_comment(sg_ay_dict, sg_session, ayon_entity_hub)
         return
 

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -379,7 +379,6 @@ def update_ayon_entity_from_sg_event(
         return
 
     if sg_ay_dict["type"].lower() == "comment":
-        import pdb ; pdb.set_trace()
         handle_comment(sg_ay_dict, sg_session, ayon_entity_hub)
         return
 

--- a/services/shotgrid_common/constants.py
+++ b/services/shotgrid_common/constants.py
@@ -168,3 +168,11 @@ class FOLDER_REPARENTING_TYPE:
 SHOTGRID_COMMENTS_TOPIC = "shotgrid.sync.comments"
 COMMENTS_SYNC_INTERVAL = 15  # secs
 COMMENTS_SYNC_TIMEOUT = 60 * 2  # secs
+COMMENTS_PARENTING_ORDER = (
+    "version",
+    "shot",
+    "asset",
+    "sequence",
+    "episode",
+    "project"
+)

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1,4 +1,3 @@
-import copy
 import os
 import json
 import hashlib

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1557,8 +1557,6 @@ def handle_comment(sg_ay_dict, sg_session, entity_hub):
         return
 
     ayon_user_name = _get_ayon_user_name(sg_note["user"])
-    if not ayon_user_name:
-        return
 
     ay_parent_entity = _get_sg_note_parent_entity(entity_hub, sg_note, sg_session)
     if not ay_parent_entity:


### PR DESCRIPTION
## Changelog Description

resolve: #181 

## Additional review information

It looks like there is a bug in SG where Note made from the ApiUser do not show up in the Activity page.
E.g. when a user create a comment in AYON to a specific version, it gets reported in Flow but does not appear in the Activity page, of the version.. however I can see it properly in the overhall Note page.
Adding the shot entity in the `note_links` the same way Flow is doing it does not solve anything.. this looks like a bug to me.

![image](https://github.com/user-attachments/assets/62361cc1-d174-40e0-8e76-344b79bf941e)
![image](https://github.com/user-attachments/assets/15f91d00-195e-44c2-92d9-c1f53f944623)


## Testing notes:
1. From an auto-sync project between Flow and AYON
2a. Create a note for a Version in the Activity page and ensure it gets synced to the equivalent Version in AYON
2b. Create a comment in AYON from an unsynced user and ensure it gets created in Flow (unassigned)
