### PR TITLE
syncs attachments on SG notes to AYON

### DIFF
--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1782,7 +1782,6 @@ def _add_comment(
             attachment_paths = [atch["local_path"] for atch in sg_note["attachments"]]
             for path in attachment_paths:
                 mime_type, _ = mimetypes.guess_type(path)
-                log.info(f"{mime_type = }")
                 headers = {
                     "Content-Type": mime_type,
                     "x-file-name": os.path.basename(path),

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1668,11 +1668,19 @@ def _get_sg_note(sg_note_id, sg_session):
     if sg_note.get("attachments"):
         # download attachments locally
         for attachment in sg_note["attachments"]:
-            with tempfile.NamedTemporaryFile(
-                delete=False,
-                suffix=attachment["name"]
-            ) as tmp_file:
-                attachment["local_path"] = sg_session.download_attachment(attachment, file_path=tmp_file.name)
+            try:
+                with tempfile.NamedTemporaryFile(
+                    delete=False,
+                    suffix=attachment["name"]
+                ) as tmp_file:
+                    attachment["local_path"] = sg_session.download_attachment(attachment, file_path=tmp_file.name)
+            except Exception as error:
+                log.warning(
+                    "Could not download note attachment for %r (attachment: %r): %r.",
+                    sg_note,
+                    attachment,
+                    error
+                )
     return sg_note, sg_note_id
 
 

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1779,8 +1779,12 @@ def _add_comment(
     with con.as_username(ayon_username):
         attachment_ids = []
         if sg_note.get("attachments"):
-            attachment_paths = [atch["local_path"] for atch in sg_note["attachments"]]
-            for path in attachment_paths:
+            for atch in sg_note["attachments"]:
+                path = atch.get("local_path")
+                if not path or not os.path.exists(path):
+                    log.debug(f"Ignore invalid attachment path: {path}")
+                    continue
+
                 mime_type, _ = mimetypes.guess_type(path)
                 headers = {
                     "Content-Type": mime_type,


### PR DESCRIPTION
## Changelog Description
Supports syncing SG note attachments to AYON.

### TODOs
- [x] sync SG attachments to AYON
- [ ] sync AYON attachments back to SG
- [ ] handle bi-directional attachment addition
- [ ] handle bi-directional attachment deletion

## Additional review information
- query SG attachment
- download file from SG in a local temp directory
- upload file to AYON
- attach uploaded file to AYON Comment
- removes temporarily downloaded files from container

