### PR TITLE
AY-7632 Ensure date attributes are synced between Flow and AYON

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -74,6 +74,12 @@ def get_default_folder_attributes():
             "scope": default_shotgrid_enabled_entities()
         }
 
+        # Project.startDate is usually not editable in Flow
+        if attr_name == "startDate":
+            reduce_scope = default_shotgrid_enabled_entities()
+            reduce_scope.remove("Project")
+            attr_map["scope"] = reduce_scope
+
         if attr_map not in attributes:
             attributes.append(attr_map)
 


### PR DESCRIPTION
## Changelog Description

resolve #180 

## Additional review information

## Testing notes:
1. Set your custom_attributes_map settings so that AYON `startDate` and `endDate` sync to `start_date` and `due_date` Flow fields.
2. **Warning `Project.start_date` is usually not editable in Flow so better to remove it**
![image](https://github.com/user-attachments/assets/3b687a45-7380-43f5-b56b-042a0c6d71af)

3. Create tasks AYON and FLOW with edited start and end dates and ensure they sync:
    3a. Sync via leecher and processor from Flow to AYON (for existing and new tasks)
    3b. Sync via transmitter and process from AYON to Flow (for existing and new tasks)
    3c. Sync when the whole projects are synced via `SG -> AYON` and `AYON -> SG` buttons
