### PR TITLE
Bi-Directional attachments sync on notes/comments

### DIFF
--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -515,7 +515,13 @@ class AyonShotgridHub:
                 )
             else:
                 sg_update_data = {}
-                activity_atchmt_names = [atchmt["filename"] for atchmt in activity_attachments]
+                activity_atchmt_names = []
+                for atchmt in activity_attachments:
+                    filename = atchmt["filename"]
+                    if "/" in filename:
+                        filename = filename.split("/")[-1]
+                    activity_atchmt_names.append(filename)
+                # activity_atchmt_names = [atchmt["filename"] for atchmt in activity_attachments]
                 for sg_atchmt in sg_note["attachments"]:
                     if sg_atchmt["name"] not in activity_atchmt_names:
                         self._sg.delete("Attachment", sg_atchmt["id"])

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -518,10 +518,11 @@ class AyonShotgridHub:
                 activity_atchmt_names = []
                 for atchmt in activity_attachments:
                     filename = atchmt["filename"]
+                    # handles filenames containing slashes which is happening when using the powerpack annotations in AYON
                     if "/" in filename:
                         filename = filename.split("/")[-1]
                     activity_atchmt_names.append(filename)
-                # activity_atchmt_names = [atchmt["filename"] for atchmt in activity_attachments]
+
                 for sg_atchmt in sg_note["attachments"]:
                     if sg_atchmt["name"] not in activity_atchmt_names:
                         self._sg.delete("Attachment", sg_atchmt["id"])

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -519,6 +519,7 @@ class AyonShotgridHub:
                 for sg_atchmt in sg_note["attachments"]:
                     if sg_atchmt["name"] not in activity_atchmt_names:
                         self._sg.delete("Attachment", sg_atchmt["id"])
+                        self.log.info(f"Deleted attachment {sg_atchmt['name']} from SG.")
 
                 if sg_note["content"] != activity["body"]:
                     sg_update_data["content"] = activity["body"]
@@ -645,6 +646,7 @@ class AyonShotgridHub:
                 filepath=tmp_file,
             )
             self._sg.upload("Note", note_id, tmp_file)
+            self.log.info(f"Uploaded AYON attachment {atchmt['filename']} to SG.")
             os.remove(tmp_file)
 
 

--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -640,11 +640,13 @@ class AyonShotgridHub:
         # download attachments temporarily to upload to SG
         tmp_dir = tempfile.mkdtemp()
         for atchmt in activity_data["files"]:
+            self.log.debug(f"{atchmt = }")
             tmp_file = os.path.join(tmp_dir, atchmt["filename"])
             ayon_api.download_file(
                 endpoint=f"projects/{project_name}/files/{atchmt['id']}",
                 filepath=tmp_file,
             )
+            self.log.debug(f"Downloaded AYON attachment {atchmt['filename']} to {tmp_file}.")
             self._sg.upload("Note", note_id, tmp_file)
             self.log.info(f"Uploaded AYON attachment {atchmt['filename']} to SG.")
             os.remove(tmp_file)

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1782,7 +1782,6 @@ def _add_comment(
             attachment_paths = [atch["local_path"] for atch in sg_note["attachments"]]
             for path in attachment_paths:
                 mime_type, _ = mimetypes.guess_type(path)
-                log.info(f"{mime_type = }")
                 headers = {
                     "Content-Type": mime_type,
                     "x-file-name": os.path.basename(path),

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1668,11 +1668,19 @@ def _get_sg_note(sg_note_id, sg_session):
     if sg_note.get("attachments"):
         # download attachments locally
         for attachment in sg_note["attachments"]:
-            with tempfile.NamedTemporaryFile(
-                delete=False,
-                suffix=attachment["name"]
-            ) as tmp_file:
-                attachment["local_path"] = sg_session.download_attachment(attachment, file_path=tmp_file.name)
+            try:
+                with tempfile.NamedTemporaryFile(
+                    delete=False,
+                    suffix=attachment["name"]
+                ) as tmp_file:
+                    attachment["local_path"] = sg_session.download_attachment(attachment, file_path=tmp_file.name)
+            except Exception as error:
+                log.warning(
+                    "Could not download note attachment for %r (attachment: %r): %r.",
+                    sg_note,
+                    attachment,
+                    error
+                )
     return sg_note, sg_note_id
 
 

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1779,8 +1779,12 @@ def _add_comment(
     with con.as_username(ayon_username):
         attachment_ids = []
         if sg_note.get("attachments"):
-            attachment_paths = [atch["local_path"] for atch in sg_note["attachments"]]
-            for path in attachment_paths:
+            for atch in sg_note["attachments"]:
+                path = atch.get("local_path")
+                if not path or not os.path.exists(path):
+                    log.debug(f"Ignore invalid attachment path: {path}")
+                    continue
+
                 mime_type, _ = mimetypes.guess_type(path)
                 headers = {
                     "Content-Type": mime_type,


### PR DESCRIPTION
## Changelog Description
Supports bi-directional note attachments sync between AYON and SG.

- gets uploaded attachments and temporarily downloads them locally
- downloaded attachment is uploaded to the other CMS
- removing an attachment is reflected in the opponent CMS

## Testing Notes
- it's not possible to add additional attachments after a note is created neither in AYON nor in SG

### TODOs
- [x] sync SG attachments to AYON
- [x] sync AYON attachments back to SG
- [x] handle bi-directional attachment deletion
- [ ] listen to SG event also when only the `attachments` field is updated

