### PR TITLE
Sync version without task

### DIFF
--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -2049,10 +2049,15 @@ def create_new_sg_entity(
         data["description"] = ay_entity.attribs.get("comment")
 
         # sync productType as version type
-        product_data =  ayon_api.get_product_by_id(ay_project_name, ay_entity.product_id)
+        product_data =  ayon_api.get_product_by_id(
+            ay_project_name,
+            ay_entity.product_id
+        )
         sg_version_field = sg_session.schema_field_read(
             "Version", "sg_version_type")["sg_version_type"]
-        sg_valid_values = sg_version_field["properties"]["valid_values"]["value"]
+        sg_valid_values = (
+            sg_version_field["properties"]["valid_values"]["value"]
+        )
 
         if product_data["productType"] in sg_valid_values:
             data["sg_version_type"] = product_data["productType"]

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -2036,10 +2036,14 @@ def create_new_sg_entity(
             data["user"] = {'type': 'HumanUser', 'id': sg_user_id}
 
         # sync associated task
-        task_data = ayon_api.get_task_by_id(ay_project_name, ay_entity.task_id)
-        sg_task = task_data["attrib"].get(SHOTGRID_ID_ATTRIB)
-        if sg_task:
-            data["sg_task"] = {"type": "Task", "id": int(sg_task)}
+        if ay_entity.task_id:
+            task_data = ayon_api.get_task_by_id(
+                ay_project_name,
+                ay_entity.task_id
+            )
+            sg_task = task_data["attrib"].get(SHOTGRID_ID_ATTRIB)
+            if sg_task:
+                data["sg_task"] = {"type": "Task", "id": int(sg_task)}
 
         # sync comment for description
         data["description"] = ay_entity.attribs.get("comment")


### PR DESCRIPTION
## Changelog Description
Task is optional in AYON, this solves synchronization issues when there was no task assigned to Version.

## Additional review information
Fixes:
```
    sg_ay_dict = create_new_sg_entity(
                 ^^^^^^^^^^^^^^^^^^^^^
  File "/service/utils.py", line 2039, in create_new_sg_entity
    task_data = ayon_api.get_task_by_id(ay_project_name, ay_entity.task_id)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ayon_api/_api.py", line 4038, in get_task_by_id
    return con.get_task_by_id(
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ayon_api/server_api.py", line 5382, in get_task_by_id
    for task in self.get_tasks(
  File "/usr/local/lib/python3.11/site-packages/ayon_api/server_api.py", line 5314, in get_tasks
    for parsed_data in query.continuous_query(self):
  File "/usr/local/lib/python3.11/site-packages/ayon_api/graphql.py", line 399, in continuous_query
    raise GraphQlQueryFailed(
ayon_api.exceptions.GraphQlQueryFailed: GraphQl query Failed: Variable '$taskIds' got invalid value None at 'taskIds[0]'; Expected non-nullable type 'String!' not to be None. (Line 1 Column 40)
```

AY-7794

## Testing notes:
1. publish Version without task (easiest with Traypublisher)
2. run full sync from AYON to SG
