### PR TITLE
Fix broken status update on new SG entity.

### DIFF
--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -128,7 +128,11 @@ def create_ay_entity_from_sg_event(
             log.debug("ShotGrid Entity exists in AYON.")
             # Ensure AYON Entity has the correct ShotGrid ID
             ay_entity = _update_sg_id(
-                ay_entity, custom_attribs_map, sg_ay_dict)
+                ay_entity,
+                custom_attribs_map,
+                sg_ay_dict,
+                ayon_entity_hub
+            )
 
             return ay_entity
 
@@ -310,7 +314,7 @@ def _get_ayon_parent_entity(
     return ay_parent_entity
 
 
-def _update_sg_id(ay_entity, custom_attribs_map, sg_ay_dict):
+def _update_sg_id(ay_entity, custom_attribs_map, sg_ay_dict, entity_hub):
     ayon_entity_sg_id = str(
         ay_entity.attribs.get_attribute(SHOTGRID_ID_ATTRIB).value)
     # Ensure AYON Entity has the correct Shotgrid ID
@@ -326,7 +330,10 @@ def _update_sg_id(ay_entity, custom_attribs_map, sg_ay_dict):
             sg_ay_dict["type"]
         )
     update_ay_entity_custom_attributes(
-        ay_entity, sg_ay_dict, custom_attribs_map
+        ay_entity,
+        sg_ay_dict,
+        custom_attribs_map,
+        ay_project=entity_hub.project_entity,
     )
 
     return ay_entity
@@ -394,7 +401,8 @@ def update_ayon_entity_from_sg_event(
                 ayon_entity_hub,
                 sg_enabled_entities,
                 project_code_field,
-                custom_attribs_map
+                custom_attribs_map,
+                addon_settings=addon_settings
             )
         except Exception:
             log.debug("AYON Entity could not be created", exc_info=True)


### PR DESCRIPTION
## Changelog Description

Fix an issue when syncing a new SG entity to AYON through an update event.

## Additional review information
```
Traceback (most recent call last):
  File "/service/processor/processor.py", line 266, in start_processing
    handler.process_event(
  File "/service/processor/handlers/shotgrid_event.py", line 37, in process_event
    hub.react_to_shotgrid_event(sg_payload["meta"])
  File "/service/ayon_shotgrid_hub/__init__.py", line 325, in react_to_shotgrid_event
    create_ay_entity_from_sg_event(
  File "/service/ayon_shotgrid_hub/update_from_shotgrid.py", line 130, in create_ay_entity_from_sg_event
    ay_entity = _update_sg_id(
                ^^^^^^^^^^^^^^
  File "/service/ayon_shotgrid_hub/update_from_shotgrid.py", line 328, in _update_sg_id
    update_ay_entity_custom_attributes(
  File "/service/utils.py", line 1352, in update_ay_entity_custom_attributes
    for status in ay_project.statuses
                  ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'statuses'
```

## Testing notes:
1. Create a new SG entity with no equivalent in AYON
2. Enable auto-sync
3. Update the entity status field and ensure new AYON entity is created with proper status
