### PR TITLE
Skip folder sync to SG when parent SG ID is missing.

### DIFF
--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -229,12 +229,21 @@ def match_ayon_hierarchy_in_shotgrid(
 
         # entity was not synced before and need to be created
         if not sg_entity_id or not sg_ay_dict:
+
+            sg_parent_id = sg_ay_parent_entity["attribs"][SHOTGRID_ID_ATTRIB]
+            if sg_parent_id is None:
+                log.warning(
+                    f"AYON parent entity {sg_ay_parent_entity} not found in SG, "
+                    f"{ay_entity} couldn't be created."
+                )
+                continue
+
             sg_parent_entity = sg_session.find_one(
                 sg_ay_parent_entity["attribs"][SHOTGRID_TYPE_ATTRIB],
                 filters=[[
                     "id",
                     "is",
-                    int(sg_ay_parent_entity["attribs"][SHOTGRID_ID_ATTRIB])
+                    int(sg_parent_id)
                 ]]
             )
             sg_ay_dict = create_new_sg_entity(

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -230,7 +230,7 @@ def match_ayon_hierarchy_in_shotgrid(
         # entity was not synced before and need to be created
         if not sg_entity_id or not sg_ay_dict:
 
-            sg_parent_id = sg_ay_parent_entity["attribs"][SHOTGRID_ID_ATTRIB]
+            sg_parent_id = sg_ay_parent_entity["attribs"].get(SHOTGRID_ID_ATTRIB)
             if sg_parent_id is None:
                 log.warning(
                     f"AYON parent entity {sg_ay_parent_entity} not found in SG, "
@@ -239,7 +239,7 @@ def match_ayon_hierarchy_in_shotgrid(
                 continue
 
             sg_parent_entity = sg_session.find_one(
-                sg_ay_parent_entity["attribs"][SHOTGRID_TYPE_ATTRIB],
+                sg_ay_parent_entity["attribs"].get(SHOTGRID_TYPE_ATTRIB),
                 filters=[[
                     "id",
                     "is",

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
@@ -84,6 +84,10 @@ def create_sg_entity_from_ayon_event(
         sg_parent_entity = _get_sg_parent_entity(
             sg_session, ay_entity, ayon_event)
 
+        if sg_parent_entity is None:
+            log.warning(f"Couldn't create SG entity for '{ay_id}, parent not found.")
+            return
+
         sg_entity = create_new_sg_entity(
             ay_entity,
             sg_session,
@@ -161,6 +165,10 @@ def _get_sg_parent_entity(sg_session, ay_entity, ayon_event):
     else:
         sg_parent_id = ay_entity.parent.attribs.get(SHOTGRID_ID_ATTRIB)
         sg_parent_type = ay_entity.parent.attribs.get(SHOTGRID_TYPE_ATTRIB)
+
+    if sg_parent_type is None or sg_parent_id is None:
+        return None
+
     sg_parent_entity = sg_session.find_one(
         sg_parent_type,
         filters=[[


### PR DESCRIPTION
## Changelog Description

Fixes temporarily:
```
2025-05-12 19:10:26.568 ERROR: Unable to process handler sync_projects
Traceback (most recent call last):
File "/service/processor/processor.py", line 266, in start_processing
handler.process_event(
File "/service/processor/handlers/sync_projects.py", line 34, in process_event
hub.synchronize_projects(source=sync_source)
File "/service/ayon_shotgrid_hub/__init__.py", line 249, in synchronize_projects
match_ayon_hierarchy_in_shotgrid(
File "/service/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py", line 237, in match_ayon_hierarchy_in_shotgrid
int(sg_ay_parent_entity["attribs"][SHOTGRID_ID_ATTRIB])
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

while https://github.com/ynput/ayon-shotgrid/issues/193 is investigated.
