### PR TITLE
Fix Synchronize Users for existing user login.

### DIFF
--- a/frontend/dist/shotgrid-addon.js
+++ b/frontend/dist/shotgrid-addon.js
@@ -164,7 +164,7 @@ const syncUsers = async () => {
       console.log("sg_user already exists.")
     }
     else {
-        // make sure no @ and . or - is in login string
+        // make sure no @ and validate login string
         let ay_fixed_login = validateLogin(sg_user.login);
         let login_already_exists = false;
 
@@ -333,7 +333,7 @@ const updateUserInAyon = async (id, login) => {
   /* Update an existing AYON user to set its sg_user_id. */
   call_result_paragraph = document.getElementById("call-result");
 
-  // make sure no @ and . or - is in login string
+  // make sure no @ and validate login string
   let fixed_login = validateLogin(login);
 
   response = await ayonAPI
@@ -354,7 +354,7 @@ const createNewUserInAyon = async (id, login, email, name) => {
   /* Create a new AYON user.*/
   call_result_paragraph = document.getElementById("call-result");
 
-  // make sure no @ and . or - is in login string
+  // make sure no @ and validate login string
   let fixed_login = validateLogin(login);
 
   response = await ayonAPI

--- a/frontend/dist/shotgrid-addon.js
+++ b/frontend/dist/shotgrid-addon.js
@@ -153,6 +153,7 @@ const populateTable = async () => {
 const syncUsers = async () => {
   /* Get all the Users from AYON and Shotgrid, then populate the table with their info
   and a button to Synchronize if they pass the requirements */
+  ayonUsers = await getAyonUsers();
   sgUsers = await getShotgridUsers();
 
   let new_users = []
@@ -163,9 +164,28 @@ const syncUsers = async () => {
       console.log("sg_user already exists.")
     }
     else {
+        // make sure no @ and . or - is in login string
+        let ay_fixed_login = validateLogin(sg_user.login);
+        let login_already_exists = false;
+
+        ayonUsers.forEach((user) => {
+          if (ay_fixed_login == user.name) {
+              login_already_exists = true
+          }
+        })
+
+        // User login exists in AYON but no associated sg_user_id.
+        if (login_already_exists){
+          updateUserInAyon(sg_user.id, sg_user.login)
+        }
+
+        // User login does not exist in AYON.
+        else {
+          createNewUserInAyon(
+            sg_user.id, sg_user.login, sg_user.email, sg_user.name)
+        }
+
       new_users.push(sg_user.name)
-      createNewUserInAyon(
-        sg_user.id ,sg_user.login, sg_user.email, sg_user.name)
     }
   }
 
@@ -309,9 +329,29 @@ function validateLogin(login) {
   return new_login;
 }
 
+const updateUserInAyon = async (id, login) => {
+  /* Update an existing AYON user to set its sg_user_id. */
+  call_result_paragraph = document.getElementById("call-result");
+
+  // make sure no @ and . or - is in login string
+  let fixed_login = validateLogin(login);
+
+  response = await ayonAPI
+    .patch("/api/users/" + fixed_login, {
+      "data": {
+        "sg_user_id": id
+      },
+    })
+    .then((result) => result)
+    .catch((error) => {
+      console.log("Unable to update user in AYON!")
+      console.log(error)
+      call_result_paragraph.innerHTML = `Unable to update user in AYON! ${error}`
+    });
+}
+
 const createNewUserInAyon = async (id, login, email, name) => {
-  /* Spawn an AYON Event of topic "shotgrid.event" to synchcronize a project
-  from Shotgrid into AYON. */
+  /* Create a new AYON user.*/
   call_result_paragraph = document.getElementById("call-result");
 
   // make sure no @ and . or - is in login string


### PR DESCRIPTION
## Changelog Description

Currently when clicking the `Synchronize Users` button in the Shotgrid tab there are 2 options:
* An AYON user exists with the proper `sg_user_id` set, user creation is skipped
* No AYON user can be found, we create a new one reporting the Flow login

However there is a third case:
* A AYON user exists whose name matches the relevant Flow login, but it does not store any `sg_user_id`. This means we need to update the existing user to set its `sg_user_id` attribute.

Currently this was failing with user creation stucked (Conflict 409, login already exists).

## Testing notes:
1. Package this changes and upload in AYON server
2. Create a dummy AYON user manually whose login matches an existing login in FLOW. Creating it manually ensure 
3. Check its `sg_user_id` is inexistant `$SERVER_URL/api/users/<USER_LOGIN>`
4. Click the "Synchronize Users" button and ensure user get synced back
5. Check that `sg_user_id` is now set for user with `$SERVER_URL/api/users/<USER_LOGIN>`
6. (Optional) Re-clicking  "Synchronize Users" button should tell you that all is synced