### PR TITLE
Fix caching for transmitter service.

### DIFF
--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -131,6 +131,10 @@ class AyonShotgridHub:
         )
 
     @property
+    def sg_project(self):
+        return self._sg_project
+
+    @property
     def project_name(self):
         return self._project_name
 
@@ -387,9 +391,9 @@ class AyonShotgridHub:
             ayon_event (dict): A dictionary describing what
                 the change encompases, i.e. a new shot, new asset, etc.
         """
-        if not self._sg_project[CUST_FIELD_CODE_AUTO_SYNC]:
+        if not self._sg_project:
             self.log.info(
-                "Ignoring event, Shotgrid field 'Ayon Auto Sync' is disabled."
+                "Ignoring event, Shotgrid project does not exist."
             )
             return
 

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -259,7 +259,12 @@ class ShotgridTransmitter:
                 custom_attribs_types=self.custom_attribs_types,
                 sg_enabled_entities=self.sg_enabled_entities,
             )
-            self._cached_hubs[project_name] = hub
+
+            # Do not cache the hub object
+            # if the SG project does not exist (yet?).
+            # This is to force refresh on next event.
+            if hub.sg_project is not None:
+                self._cached_hubs[project_name] = hub
 
         return hub
 


### PR DESCRIPTION
## Changelog Description

The `transmitter` service caches the `AyonShotgridHub` objects per project.
However this introduce a side case, if Flow projects get created AFTER the `transmitter` service is started, it will not detect them anymore and ignore their event.

This generated inconsistent behavior with `processor` and `leecher` services automatically refreshing but `transmitter` did not.

## Testing notes:
1. Create an AYON project (enabling `shotgridPush`) with no Flow project counterpart
2. Start the `transmitter` and `processor` services
3. Create manually some folders in the new AYON project, nothing should happens
4. Manually sync the project using `AYON -> SG` button, creating the Flow project
5. Re-create some new folders, ensure this time they get synced properly
