### PR TITLE
Fix editorial hierarchy and version syncing.

### DIFF
--- a/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/__init__.py
@@ -421,6 +421,9 @@ class AyonShotgridHub:
                     ayon_event,
                     self._sg,
                     self._ay_project,
+                    self._sg_project,
+                    self.sg_enabled_entities,
+                    self.sg_project_code_field,
                     self.custom_attribs_map,
                     self.settings
                 )
@@ -436,6 +439,9 @@ class AyonShotgridHub:
                     ayon_event,
                     self._sg,
                     self._ay_project,
+                    self._sg_project,
+                    self.sg_enabled_entities,
+                    self.sg_project_code_field,
                     self.custom_attribs_map,
                     self.settings,
                 )
@@ -445,6 +451,7 @@ class AyonShotgridHub:
                 | "entity.task.tags_changed"
                 | "entity.folder.tags_changed"
                 | "entity.task.assignees_changed"
+                | "entity.version.status_changed"
             ):
                 # TODO: for some reason the payload here is not a dict but we know
                 # we always want to update the entity
@@ -452,6 +459,9 @@ class AyonShotgridHub:
                     ayon_event,
                     self._sg,
                     self._ay_project,
+                    self._sg_project,
+                    self.sg_enabled_entities,
+                    self.sg_project_code_field,
                     self.custom_attribs_map,
                     self.settings,
                 )
@@ -464,7 +474,7 @@ class AyonShotgridHub:
                 )
             case _:
                 raise ValueError(
-                    f"Unable to process event {ayon_event['topic']}."
+                    f"Unable to process event {ayon_event['topic']} (unsupported event)."
                 )
 
     def sync_comments(self, activities_after_date):

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -87,13 +87,6 @@ def match_ayon_hierarchy_in_shotgrid(
             ),
             ay_entity_child
         ))
-    versions = ayon_api.get_versions(entity_hub.project_name)
-    for version in versions:
-        product_entity = entity_hub.get_product_by_id(version["productId"])
-        ay_entity_deck.append(
-            (product_entity.parent,
-             entity_hub.get_version_by_id(version["id"]))
-        )
 
     ay_project_sync_status = "Synced"
     processed_ids = set()
@@ -336,7 +329,21 @@ def _add_items_to_queue(
         ay_entity (Union[TaskEntity, FolderEntity]): The AYON entity.
         sg_ay_dict (Dict): The Shotgrid AYON entity dictionary.
     """
+    # Add children entity
     for ay_entity_child in entity_hub._entities_by_parent_id.get(
                 ay_entity.id, []
             ):
         ay_entity_deck.append((sg_ay_dict, ay_entity_child))
+
+    # Add direct children version underneath
+    versions = ayon_api.get_versions(entity_hub.project_name)
+    for version in versions:
+        product_entity = entity_hub.get_product_by_id(version["productId"])
+
+        if product_entity.parent.id == ay_entity.id:
+            ay_entity_deck.append(
+                (
+                    sg_ay_dict,
+                    entity_hub.get_version_by_id(version["id"])
+                )
+            )


### PR DESCRIPTION
## Changelog Description

resolve #193 

Editorial publish are a bit specific:
* Version, sequence and shots are created all at once
* New hierarchy might be parented underneath a generic `shots` folder (type `Folder`)
* Product might not be associated with tasks

This PR fixes the following:
* manual project sync: ensure `Version` get synced after their parent folder gets created and not before
* automated sync: 
    * ensure proper parenting even when generic folder is part of the hierarchy
    * attempt to create SG entity from an update if its missing (this can happen if the service did not run at editorial creation)
    * support status change from `Version` for AYON -> SG 

## Testing notes:

Automated sync:
1. Turn on automated sync (ShotgridPush)
2. Create an editorial hierarchy through Resolve, Flame or Hiero with new sequence, shots and version(s)
3. Ensure everything get synced and parented accordingly

Manual sync:
1. Turn off automated sync
2. Create an editorial hierarchy through Resolve, Flame or Hiero with new sequence, shots and version(s)
3. Trigger a manual project sync AYON -> SG
4. Ensure everything get synced and parented accordingly


