### PR TITLE
Ignore SG events coming from ourselves.

### DIFF
--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -125,6 +125,11 @@ class ShotgridListener:
             self.log.error("Unable to connect to Shotgrid Instance:")
             raise e
 
+        self.sg_current_api_user = self.sg_session.find_one(
+            "ApiUser",
+            [["firstname", "is", self.sg_script_name]]
+        )
+
         signal.signal(signal.SIGINT, self._signal_teardown_handler)
         signal.signal(signal.SIGTERM, self._signal_teardown_handler)
 
@@ -355,19 +360,24 @@ class ShotgridListener:
                 self.log.error(traceback.format_exc())
 
     def _is_api_user_event(self, event: dict[str, Any]) -> bool:
-        """Check if the event was caused by an API user.
+        """Check if the event was caused by our API user.
 
         Args:
             event (dict): The Shotgrid Event data.
 
         Returns:
-            bool: True if the event was caused by an API user.
+            bool: True if the event was caused by our API user.
         """
-        # TODO: we have to create specific api user filtering
+        # Ignore events that are comming from ourselves.
+        # Other ApiUser generated events are OK.
         if (
-            event.get("meta", {}).get("sudo_actual_user", {}).get("type")
-            == "ApiUser"
+            event.get("user", {}).get("type") == "ApiUser"
+            and event.get("user", {}).get("id") == self.sg_current_api_user["id"]
         ):
+            self.log.warning(
+                "Ignore event from the AYON<->SG service ApiUser. "
+                f"Better turn off events generation for {self.sg_script_name} in Flow."
+            )
             return True
 
     def send_shotgrid_event_to_ayon(


### PR DESCRIPTION
## Changelog Description

Our `leecher` service code was not ignoring events coming from us, and supposely ignoring anything from `ApiUser`.

I believe this is wrong, we should only ignore events generated by the AYON<->SG API script.
Everything else is OK to go through.

## Testing notes:

![image](https://github.com/user-attachments/assets/d986656b-8d9e-4e9f-8082-b537f3d1bcc4)


1. Ensure that the ApiScript that handle the sync in Flow has is generating events
2. Make some sync from AYON to SG.
3. Ensure that the resulting events are ignored by the leecher
4. Turn off event generation for the ApiUser.
