### PR TITLE
Support all Flow project tracking settings.

### DIFF
--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -824,7 +824,14 @@ def get_sg_entities(
                 and sg_entity[parent_field]
                 and entity_name != "Asset"
             ):
-                parent_id = sg_entity[parent_field]["id"]
+
+                sg_parent = sg_entity[parent_field]
+
+                # Parenting in Project tracking settings can
+                # point to a non-entity entry (e.g. AYON Sync status).
+                # Set parent id only if defined parent is a valid entity.
+                if isinstance(sg_parent, dict) and sg_parent.get("id"):
+                    parent_id = sg_parent["id"]
 
             # Reparent the current SG Asset under an AssetCategory ?
             elif (


### PR DESCRIPTION
## Changelog Description

There is a bug when the Flow project tracking settings is set to a non-entity object.
![image](https://github.com/user-attachments/assets/a9209fca-df73-4143-8808-9a0a1e9de93a)

Which failed with the error log:
```
2025-05-19 15:48:00.718 ERROR: Unable to process handler sync_projects
Traceback (most recent call last):
  File "/service/processor/processor.py", line 251, in start_processing
    handler.process_event(
  File "/service/processor/handlers/sync_projects.py", line 34, in process_event
    hub.synchronize_projects(source=sync_source)
  File "/service/ayon_shotgrid_hub/__init__.py", line 266, in synchronize_projects
    match_ayon_hierarchy_in_shotgrid(
  File "/service/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py", line 62, in match_ayon_hierarchy_in_shotgrid
    sg_ay_dicts, sg_ay_dicts_parents = get_sg_entities(
                                       ^^^^^^^^^^^^^^^^
  File "/service/utils.py", line 817, in get_sg_entities
    parent_id = sg_entity[parent_field]["id"]
                ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
TypeError: string indices must be integers, not 'str'
```

## Testing notes:
1. Change the project tracking settings to link `Episode`, `Sequence` or `Shot` under a non-entity object (.e.g `Ayon Sync status`)
2. Process with a manual sync from the `Shotgrid` tab
3. Ensure all entities sync properly
