### PR TITLE
Implement SSL validation via server settings.

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -297,6 +297,11 @@ class ShotgridSettings(BaseSettingsModel):
 
         return value
 
+    shotgrid_no_ssl_validation: bool = SettingsField(
+        False,
+        title="No SSL validation",
+        description="Turns off hostname matching validation for SSL certificates.",
+    )
     shotgrid_project_code_field: str = SettingsField(
         default="code",
         title="ShotGrid Project Code field name",

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -114,6 +114,11 @@ class ShotgridListener:
                 "Unable to get Addon settings from the server.")
             raise e
 
+        # SSL validation
+        if self.settings.get("shotgrid_no_ssl_validation", False):
+            shotgun_api3.NO_SSL_VALIDATION = True
+            self.log.info("SSL validation is disabled.")
+
         try:
             self.sg_session = shotgun_api3.Shotgun(
                 self.sg_url,

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -88,6 +88,11 @@ class ShotgridProcessor:
             except Exception:
                 self.sg_polling_frequency = 10
 
+            # SSL validation
+            if self.settings.get("shotgrid_no_ssl_validation", False):
+                shotgun_api3.NO_SSL_VALIDATION = True
+                self.log.info("SSL validation is disabled.")
+
             sg_connection = self.get_sg_connection()
 
             self.custom_attribs_map = {

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -77,6 +77,11 @@ class ShotgridTransmitter:
                     "the Addon System settings."
                 )
 
+            # SSL validation
+            if self.settings.get("shotgrid_no_ssl_validation", False):
+                shotgun_api3.NO_SSL_VALIDATION = True
+                self.log.info("SSL validation is disabled.")
+
             # Compatibility settings
             custom_attribs_map = self.settings["compatibility_settings"][
                 "custom_attribs_map"]


### PR DESCRIPTION
## Changelog Description

resolve #127 

It appears that SSL certificates might be the root cause of the of the issues people experience when uploading media to SG:
* https://community.ynput.io/t/sg-flow-addon-ssl-troubleshooting/1676/4
* https://community.shotgridsoftware.com/t/ssl-error-when-uploading-version-through-api/945/11
* https://community.shotgridsoftware.com/t/certificate-verify-failed-error-on-windows/8860
* https://community.shotgridsoftware.com/t/ssl-error-when-uploading-version-through-api/945/14

From the API, `shotgrid_api3.NO_SSL_VALIDATION`  enables to work-around SSL validations. 

This PR exposes this feature through a server settings for troubleshoot purposes:
![image](https://github.com/user-attachments/assets/4edd9d98-0281-4bab-afa8-b0cf21605516)

## Additional review information

While it might work temporarily, disabling SSL globally is NOT the recommended permanent solution.
If any issue with SSL, refer to: https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_qa_troubleshooting_qa_fix_ssl_certificate_verify_failed_html

## Testing notes:
0. Create a new package and upload to the server
1. Disable SSL validation from the server settings. `ayon+settings://shotgrid/shotgrid_no_ssl_validation`
2. Ensure the services from `ayon-shotgrid` still works as expected.
