### PR TITLE
Make services validate provided sg_url instead of server.

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -1,4 +1,3 @@
-import requests
 from pydantic import validator
 
 from ayon_server.exceptions import BadRequestException
@@ -285,17 +284,6 @@ class ShotgridSettings(BaseSettingsModel):
         example="https://my-site.shotgrid.autodesk.com",
         scope=["studio"]
     )
-
-    @validator("shotgrid_server")
-    def ensure_requests(cls, value):
-        """ Ensure provided shotgrid_server URL is valid.
-        """
-        if value:
-            resp = requests.get(value)
-            if not resp.ok:
-                raise BadRequestException(f"Unreachable URL: {value}")
-
-        return value
 
     shotgrid_no_ssl_validation: bool = SettingsField(
         False,

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -28,6 +28,8 @@ from constants import (
 import ayon_api
 import shotgun_api3
 
+import validate
+
 # TODO: remove hash in future since it is only used as backward compatibility
 LAST_EVENT_QUERY = """query LastShotgridEvent($eventTopic: String!) {
   events(last: 20, topics: [$eventTopic]) {
@@ -120,6 +122,7 @@ class ShotgridListener:
             self.log.info("SSL validation is disabled.")
 
         try:
+            validate.validate_sg_url(self.sg_url)
             self.sg_session = shotgun_api3.Shotgun(
                 self.sg_url,
                 script_name=self.sg_script_name,

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -183,6 +183,7 @@ class ShotgridProcessor:
 
         if self._sg is None:
             try:
+                validate.validate_sg_url(self.sg_url)
                 self._sg = shotgun_api3.Shotgun(
                     self.sg_url,
                     script_name=self.sg_script_name,

--- a/services/shotgrid_common/validate.py
+++ b/services/shotgrid_common/validate.py
@@ -129,7 +129,7 @@ def validate_sg_url(sg_url):
         resp = requests.get(sg_url)
         if not resp.ok:
             raise RuntimeError(
-                f"Issue reaching {sg_url}: {resp.text}"
+                f"Issue reaching {sg_url}: {resp.reason}"
             )
 
     except Exception as error:

--- a/services/shotgrid_common/validate.py
+++ b/services/shotgrid_common/validate.py
@@ -1,6 +1,7 @@
 """ Validation
 """
 import collections
+import requests
 
 import ayon_api
 from ayon_api.entity_hub import EntityHub
@@ -119,6 +120,20 @@ def _validate_project_statuses_mapping(
             )
 
     return report
+
+
+def validate_sg_url(sg_url):
+    """ Ensure provided shotgrid_server URL is valid.
+    """
+    try:
+        resp = requests.get(sg_url)
+        if not resp.ok:
+            raise RuntimeError(
+                f"Issue reaching {sg_url}: {resp.text}"
+            )
+
+    except Exception as error:
+        raise ValueError(f"Unreachable URL: {sg_url}") from error
 
 
 def validate_projects_sync(


### PR DESCRIPTION
## Changelog Description

This PR https://github.com/ynput/ayon-shotgrid/pull/185 introduced some validators, especially one on server side to ensure provided SG URL is reachable. Initial idea was to proactively detect typos but this approach has some caveats:
* Even if the URL is reachable by the server. nothing guarantee that the services will necessarily reach it (different hardware)
* If the validator fails on server side, it might block the server as validators are executed during settings loading as well.

## Additional review information
In the long run, this validator could be turn into a "settings actions", something that could enable us to show a button (such as "test connection" in this case) in the settings interface.

## Testing notes:
1. Create a new package with this changes and upload to server
2. Ensure `leecher` and `processor` services works properly
3. Introduce a typo in the SG URL setting `ayon+settings://shotgrid/shotgrid_server`
4. Ensure `leecher` and `processor` services fails with a proper error report
