### PR TITLE
Rework validation report from processor service.

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -255,11 +255,17 @@ class ShotgridCompatibilitySettings(BaseSettingsModel):
         """ Ensure custom attribs map does not contain duplicated SG fields.
         """
         all_sg_fields = []
+        all_ayon_attributes = []
         for entry in value:
             if entry.sg and entry.sg in all_sg_fields:
                 raise BadRequestException(f"Duplicate mapped SG field: {entry.sg}")
-            elif entry.sg:
+            if entry.ayon and entry.ayon in all_ayon_attributes:
+                raise BadRequestException(f"Duplicate mapped AYON attribute: {entry.ayon}")
+
+            if entry.sg:
                 all_sg_fields.append(entry.sg)
+            if entry.ayon:
+                all_ayon_attributes.append(entry.ayon)
 
         return value
 

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -254,8 +254,8 @@ class ShotgridCompatibilitySettings(BaseSettingsModel):
     def ensure_requests(cls, value):
         """ Ensure custom attribs map does not contain duplicated SG fields.
         """
-        all_sg_fields = []
-        all_ayon_attributes = []
+        all_sg_fields = set()
+        all_ayon_attributes = set()
         for entry in value:
             if entry.sg and entry.sg in all_sg_fields:
                 raise BadRequestException(f"Duplicate mapped SG field: {entry.sg}")
@@ -263,9 +263,9 @@ class ShotgridCompatibilitySettings(BaseSettingsModel):
                 raise BadRequestException(f"Duplicate mapped AYON attribute: {entry.ayon}")
 
             if entry.sg:
-                all_sg_fields.append(entry.sg)
+                all_sg_fields.add(entry.sg)
             if entry.ayon:
-                all_ayon_attributes.append(entry.ayon)
+                all_ayon_attributes.add(entry.ayon)
 
         return value
 

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -125,16 +125,25 @@ class ShotgridProcessor:
             raise e
 
         # Validation
-        validate.validate_projects_sync(
-            sg_connection,
-            self.sg_enabled_entities,
-            log=self.log
-        )
-        validate.validate_custom_attribs_map(
-            sg_connection,
-            self.settings["compatibility_settings"]["custom_attribs_map"],
-            log=self.log,
-        )
+        try:
+            validate.validate_projects_sync(
+                sg_connection,
+                self.sg_enabled_entities,
+                log=self.log
+            )
+            validate.validate_custom_attribs_map(
+                sg_connection,
+                self.settings["compatibility_settings"]["custom_attribs_map"],
+                log=self.log,
+            )
+
+        except ValueError as error:
+            self.log.error(
+                "The sync service cannot start properly due to invalid "
+                "configuration. Adjust it and restart the services."
+            )
+            self.log.error(error)
+            raise SystemExit from error
 
         self.handlers_map = self._get_handlers()
         if not self.handlers_map:

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
@@ -178,8 +178,8 @@ def _get_sg_parent_entity(sg_session, ay_entity, ayon_event):
                 f"Could not find Version parent folder from ID: '{folder_id}'."
             )
 
-        sg_parent_id = ayon_asset.attribs.get(SHOTGRID_ID_ATTRIB)
-        sg_parent_type = ayon_asset.attribs.get(SHOTGRID_TYPE_ATTRIB)
+        sg_parent_id = ayon_asset["attrib"].get(SHOTGRID_ID_ATTRIB)
+        sg_parent_type = ayon_asset["attrib"].get(SHOTGRID_TYPE_ATTRIB)
     else:
         sg_parent_id, sg_parent_type = _get_parent_sg_id_type(ay_entity)
 

--- a/services/shotgrid_common/validate.py
+++ b/services/shotgrid_common/validate.py
@@ -329,7 +329,7 @@ def validate_custom_attribs_map(
                             f"Attempt to sync a non-standard AYON attribute {scope}."
                             f'{entry["ayon"]}[type={entry["type"]}] to {scope}.{field_attempt} '
                             f"[type={conformed_field_type}]."
-                            "This might lead to issues and/or inconsistent results."
+                            "This may lead to issues and/or inconsistent results."
                         )
 
                     # The AYON attribute is fine. Its counterpart exists in Flow, but not in

--- a/services/shotgrid_common/validate.py
+++ b/services/shotgrid_common/validate.py
@@ -252,6 +252,10 @@ def validate_custom_attribs_map(
         "date": "datetime",
     }
 
+    reversed_type_mapping = collections.defaultdict(list)
+    for key, value in AY_SG_TYPE_MAPPING.items():
+        reversed_type_mapping[value].append(key)
+
     all_mapped_sgs = [entry["sg"] for entry in custom_attribs_map]
     all_mapped_ays = [entry["ayon"] for entry in custom_attribs_map]
 
@@ -265,10 +269,18 @@ def validate_custom_attribs_map(
     ]
 
     if duplicate_ays:
-        errors.append(f"Found duplicate settings for AYON attribute(s): {duplicate_ays}.")
+        errors.append(
+            f"Found duplicate settings for AYON attribute(s): {duplicate_ays}. "
+            "Cannot sync 2 different Flow fields to the same AYON attribute.\n"
+            "Adjust your custom attribute mapping."
+        )
 
     if duplicate_sgs:
-        errors.append(f"Found duplicate settings for SG field(s): {duplicate_sgs}.")
+        errors.append(
+            f"Found duplicate settings for SG field(s): {duplicate_sgs}. "
+            "Cannot sync 2 different AYON attribute to the same Flow field.\n"
+            "Adjust your custom attribute mapping."
+        )
 
     for entry in custom_attribs_map:
 
@@ -309,10 +321,37 @@ def validate_custom_attribs_map(
                         "unknown"
                     )
 
-                    if conformed_field_type != entry["type"]:
+                    # Configuration is trying to sync an AYON attribute type we
+                    # do not expect to be synced over Flow. Flag it to the user
+                    # as consequences are pretty unpredictable.
+                    if entry["type"] not in AY_SG_TYPE_MAPPING.values():
+                        report.append(
+                            f"Attempt to sync a non-standard AYON attribute {scope}."
+                            f'{entry["ayon"]}[type={entry["type"]}] to {scope}.{field_attempt} '
+                            f"[type={conformed_field_type}]."
+                            "This might lead to issues and/or inconsistent results."
+                        )
+
+                    # The AYON attribute is fine. Its counterpart exists in Flow, but not in
+                    # a data type we anticipated, this is likely something wrong with the Flow
+                    # field configuration.
+                    # E.g. syncing AYON attribute to a custom multi_entity Flow field.
+                    elif conformed_field_type == "unknown":
+                        expected_types = reversed_type_mapping[entry["type"]]
                         errors.append(
-                            f"SG field {scope}.{field_attempt} is of invalid type. "
-                            f'Expected "{entry["type"]}"" got "{conformed_field_type}".'
+                            f'Cannot sync AYON {scope}.{entry["ayon"]} to Flow {scope}.{field_attempt}. '
+                            f"Flow field is not of data type: {expected_types}.\n"
+                            "Adjust either Flow field configuration or the AYON mapping settings."
+                        )
+
+                    # Both AYON attribute and Flow field data types are standard,
+                    # but they do not match (e.g. syncing a number to a string).
+                    elif conformed_field_type != entry["type"]:
+                        errors.append(
+                            f'Cannot sync AYON {scope}.{entry["ayon"]} to '
+                            f"Flow field {scope}.{field_attempt} (invalid type). "
+                            f'Expected Flow data type "{entry["type"]}" got "{conformed_field_type}".\n'
+                            "Adjust either Flow field configuration or the AYON mapping settings."
                         )
 
                     break
@@ -329,4 +368,4 @@ def validate_custom_attribs_map(
 
     if errors:
         errors.insert(0, "Settings validation failed:")
-        raise ValueError("\n".join(errors))
+        raise ValueError("\n - ".join(errors))

--- a/services/tests/update_from_ayon/test_create_from_ayon.py
+++ b/services/tests/update_from_ayon/test_create_from_ayon.py
@@ -238,7 +238,7 @@ def test_create_new_version(hub_and_project):
     with mock.patch.object(EntityHub, "get_or_query_entity_by_id", return_value=version_entity), \
          mock.patch.object(VersionEntity, "parent", new_callable=mock.PropertyMock) as mock_parent, \
          mock.patch.object(ProductEntity, "parent", new_callable=mock.PropertyMock) as mock_parent_2, \
-         mock.patch.object(ayon_api, "get_folder_by_id", return_value=sequence_entity), \
+         mock.patch.object(ayon_api, "get_folder_by_id", return_value=sequence_entity.to_create_body_data()), \
          mock.patch.object(ayon_api, "get_product_by_id", return_value={"productType": "render"}), \
          mock.patch.object(utils, "get_sg_entity_parent_field", return_value="entity"), \
          mock.patch.object(utils, "_add_paths", return_value=None):


### PR DESCRIPTION
## Changelog Description

Since release `0.6.X` we have added some proactive configuration validations to ensure the whole sync configuration is OK before the `processor` service get started. (previous versions used to not validate at first and crash when attempting to sync stuff).

From [these comments](https://community.ynput.io/t/ayon-not-publishing-reviewables-to-shotgrid/2600/1) on the forums it looks like this validation is not clear enough and might be mistaken for a crash of the service.

This PR:
* Detect custom attributes mismatches even more granularly 
* Add recommended action on how to fix the problematic configuration
* Ensure `processor` exit cleanly on validation error
* Additionally fix a small bug I introduced while merging the automated tests on version update (bug was never released in prod)

## Additional review information

For example on attribute type mismatch, error report goes from:
```
Traceback (most recent call last):
  File "C:\Users\robin\OneDrive\Bureau\dev_ayon\dev\ayon-shotgrid\service_tools\main.py", line 112, in <module>
    main()
  File "C:\Users\robin\OneDrive\Bureau\dev_ayon\dev\ayon-shotgrid\service_tools\main.py", line 97, in main
    service_main()
  File "C:\Users\robin\OneDrive\Bureau\dev_ayon\dev\ayon-shotgrid\services\processor\processor\processor.py", line 312, in service_main
    shotgrid_processor = ShotgridProcessor()
  File "C:\Users\robin\OneDrive\Bureau\dev_ayon\dev\ayon-shotgrid\services\processor\processor\processor.py", line 133, in __init__
    validate.validate_custom_attribs_map(
  File "C:\Users\robin\OneDrive\Bureau\dev_ayon\dev\ayon-shotgrid\services\shotgrid_common\validate.py", line 332, in validate_custom_attribs_map
    raise ValueError("\n".join(errors))
ValueError: Settings validation failed:
SG field Project.sg_fps is of invalid type. Expected "string"" got "float".
SG field Episode.sg_fps is of invalid type. Expected "string"" got "float".
SG field Sequence.sg_fps is of invalid type. Expected "string"" got "float".
SG field Shot.sg_fps is of invalid type. Expected "string"" got "float".
SG field Asset.sg_fps is of invalid type. Expected "string"" got "float".
SG field Task.sg_fps is of invalid type. Expected "string"" got "float".
SG field Version.sg_fps is of invalid type. Expected "string"" got "float".
SG field Note.sg_fps is of invalid type. Expected "string"" got "float".
```

To:
```
2025-06-30 11:52:39.965 | processor | __init__ | ERROR: The sync service cannot start properly due to invalid configuration. Adjust it and restart the services.
2025-06-30 11:52:39.965 | processor | __init__ | ERROR: Settings validation failed:
 - Cannot sync AYON Project.priority to Flow field Project.sg_fps (invalid type). Expected Flow data type "string" got "float".
Adjust either Flow field configuration or the AYON mapping settings.
 - Cannot sync AYON Episode.priority to Flow field Episode.sg_fps (invalid type). Expected Flow data type "string" got "float".
Adjust either Flow field configuration or the AYON mapping settings.
 - Cannot sync AYON Sequence.priority to Flow field Sequence.sg_fps (invalid type). Expected Flow data type "string" got "float".
Adjust either Flow field configuration or the AYON mapping settings.
 - Cannot sync AYON Shot.priority to Flow field Shot.sg_fps (invalid type). Expected Flow data type "string" got "float".
Adjust either Flow field configuration or the AYON mapping settings.
 - Cannot sync AYON Asset.priority to Flow field Asset.sg_fps (invalid type). Expected Flow data type "string" got "float".
Adjust either Flow field configuration or the AYON mapping settings.
 - Cannot sync AYON Task.priority to Flow field Task.sg_fps (invalid type). Expected Flow data type "string" got "float".
Adjust either Flow field configuration or the AYON mapping settings.
 - Cannot sync AYON Version.priority to Flow field Version.sg_fps (invalid type). Expected Flow data type "string" got "float".
Adjust either Flow field configuration or the AYON mapping settings.
 - Cannot sync AYON Note.priority to Flow field Note.sg_fps (invalid type). Expected Flow data type "string" got "float".
Adjust either Flow field configuration or the AYON mapping settings.
PS C:\Users\robin\OneDrive\Bureau\dev_ayon\dev\ayon-shotgrid>
```

## Testing notes:
1. Create all of the wrong custom attribute mapping settings you can think of under `ayon+settings://shotgrid/compatibility_settings/custom_attribs_map`
2. Start the `processor` service
3. Ensure problem is detected and a proper advice on how to sort it out is given

Test validator:
1. Create and upload a new version of the package
2. Ensure duplicated AYON attribute in `ayon+settings://shotgrid/compatibility_settings/custom_attribs_map` is properly detected and validated
