### PR TITLE
Don't restrict shotgun_api3 version

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.poetry.dependencies]
 python = "^3.9"
-shotgun_api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }
+shotgun_api3 = "*"

--- a/services/leecher/pyproject.toml
+++ b/services/leecher/pyproject.toml
@@ -8,7 +8,7 @@ package-mode = false
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
 ayon-python-api = "^1.0.0"
-shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }
+shotgun-api3 = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -8,7 +8,7 @@ package-mode = false
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
 ayon-python-api = "^1.0.0"
-shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }
+shotgun-api3 = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/services/transmitter/pyproject.toml
+++ b/services/transmitter/pyproject.toml
@@ -9,7 +9,7 @@ package-mode = false
 python = ">=3.10,<4.0"
 arrow = "*"
 ayon-python-api = "^1.0.0"
-shotgun-api3 = { git = "https://github.com/shotgunsoftware/python-api.git", tag = "v3.4.0" }
+shotgun-api3 = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
## Changelog Description
Shotgun API is bundling *certifi* - using old version can lead to issues while connecting to SG/Flow servers.

## Additional review information
`shotgun_api3` is vendoring some libraries including `certifi`. Services using this API are connecting to various Flow/SG servers and if old version of certifi is used, the connection will fail. We can use the latest API  because we can assume that SG instances will use the latest public API too.

## Testing notes:
This is hard to test. It should just work.
