### PR TITLE
Removed obsolete validate_default

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -96,7 +96,6 @@ class ShotgridServiceSettings(BaseSettingsModel):
     polling_frequency: int = SettingsField(
         default=10,
         title="How often (in seconds) to process ShotGrid related events.",
-        validate_default=False,
     )
 
     script_key: str = SettingsField(


### PR DESCRIPTION
## Changelog Description
`validate_default` seems to be obsolete, it throws unnecessary warning in docker logs

