### PR TITLE
Fix no last event queried

### DIFF
--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -238,7 +238,8 @@ class ShotgridListener:
                 fields=["id", "project"],
                 order=[{"column": "id", "direction": "desc"}],
             )
-            last_event_id = last_event["id"]
+            if last_event:
+                last_event_id = last_event["id"]
 
         return last_event_id
 


### PR DESCRIPTION
## Changelog Description
Fixes:
```
  File "C:\Users\qam\code\ayon-shotgrid\services\leecher\leecher\listener.py", line 451, in service_main
    sys.exit(shotgrid_listener.start_listening())
  File "C:\Users\qam\code\ayon-shotgrid\services\leecher\leecher\listener.py", line 298, in start_listening
    last_event_id = self._get_last_event_processed(sg_filters)
  File "C:\Users\qam\code\ayon-shotgrid\services\leecher\leecher\listener.py", line 241, in _get_last_event_processed
    last_event_id = last_event["id"]
TypeError: 'NoneType' object is not subscriptable
```
