### PR TITLE
Fix missed break to uses preferred extension

### DIFF
--- a/client/ayon_shotgrid/plugins/publish/extract_movie_path_representation.py
+++ b/client/ayon_shotgrid/plugins/publish/extract_movie_path_representation.py
@@ -47,10 +47,9 @@ class ExtractMoviePath(pyblish.api.InstancePlugin):
             if found_repre:
                 self.log.debug(
                     f"Adding SG_use_as_movie_path for `{profile_repre_name}`")
-                self.log.info(
-                    f"Set SG_use_as_movie_path for {profile_repre_name}")
                 flow_data = found_repre.setdefault("data", {}).setdefault("flow", {})
                 flow_data["use_as_movie_path"] = True
+                break
 
     def _get_representation_profile(self, instance):
         host_name = instance.context.data["hostName"]


### PR DESCRIPTION
## Changelog Description
Use preferred configured extension if found


## Testing notes:
1. configure `ayon+settings://shotgrid/publish/ExtractMoviePath/profiles/0/repre_names` with multiple representation name
2. check SG that it pulled correct path from correct representation
