### PR TITLE
Rephrase API generative events filter out.

### DIFF
--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -383,9 +383,8 @@ class ShotgridListener:
             event.get("user", {}).get("type") == "ApiUser"
             and event.get("user", {}).get("id") == self.sg_current_api_user["id"]
         ):
-            self.log.warning(
+            self.log.debug(
                 "Ignore event from the AYON<->SG service ApiUser. "
-                f"Better turn off events generation for {self.sg_script_name} in Flow."
             )
             return True
 


### PR DESCRIPTION
## Changelog Description

We suggest to the user to disable event generations for API script that perform the Flow <> AYON sync.
However, as flagged by @MilaKudr, when the event generation is disabled, it lead to inconsistencies such as missing event in the Activity tab in Flow.
Rework the `leecher` warning to check to remove the disable event suggestion.

## Additional review information
Depending on the client needs we need to re-work the documentation to flag that:
* event generation ON: more event between gathered over the network and filtered out by the `leecher`
* event generation OFF: stuff is properly synced but notification do not appear in Activity tab

## Testing notes:
1. Restart the `leecher` with those changes and ensure it works as expected.
