### PR TITLE
fix update_ay_entity_custom_attributes call

### DIFF
--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -330,7 +330,7 @@ def _update_sg_id(ay_entity, custom_attribs_map, sg_ay_dict, project_entity):
             sg_ay_dict["type"]
         )
     update_ay_entity_custom_attributes(
-        ay_entity, sg_ay_dict, custom_attribs_map, project_entity
+        ay_entity, sg_ay_dict, custom_attribs_map, ay_project=project_entity
     )
 
     return ay_entity


### PR DESCRIPTION
## Changelog Description
[issue](https://github.com/ynput/ayon-shotgrid/issues/263)
There is a function that is not correctly called: update_ay_entity_custom_attributes
its parameter values_to_update gets the ay_project passed instead in a call
So there is a traceback happening on syncing


## Testing notes:
Since it is a very simple change, I don't have testing steps
