### PR TITLE
Sync comment only if enabled in compatibility settings

### DIFF
--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -177,7 +177,7 @@ class ShotgridTransmitter:
                 # Run comments sync
                 now_time = arrow.utcnow()
                 sec_diff = (now_time - last_comments_sync).total_seconds()
-                if sec_diff > COMMENTS_SYNC_INTERVAL and "Note" in self.sg_enabled_entities:
+                if sec_diff > COMMENTS_SYNC_INTERVAL:
                     self._sync_comments()
 
                 # enrolling only events which were not created by any
@@ -297,6 +297,10 @@ class ShotgridTransmitter:
 
         if activities_after_date is None:
             activities_after_date = now - timedelta(days=5)
+
+        if "Note" not in self.sg_enabled_entities:
+            self.log.warning("Skipping comments sync, 'Note' entity is not enabled.")
+            return
 
         response = ayon_api.dispatch_event(
             SHOTGRID_COMMENTS_TOPIC,

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -177,7 +177,7 @@ class ShotgridTransmitter:
                 # Run comments sync
                 now_time = arrow.utcnow()
                 sec_diff = (now_time - last_comments_sync).total_seconds()
-                if sec_diff > COMMENTS_SYNC_INTERVAL:
+                if sec_diff > COMMENTS_SYNC_INTERVAL and "Note" in self.sg_enabled_entities:
                     self._sync_comments()
 
                 # enrolling only events which were not created by any


### PR DESCRIPTION
adresses https://github.com/ynput/ayon-shotgrid/issues/255

## Changelog Description
Added conditional to check if `Comment` is enabled in compatibility settings and only syncs if enabled.

## Additional review information
- in my testing SG->AYON comment sync is already disabled when `Comment` isn't active in compatibility settings

## Testing notes:

