### PR TITLE
Support for syncing SG `Reply` entity

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -22,7 +22,8 @@ def default_shotgrid_entities():
         "Asset",
         "Task",
         "Version",
-        "Note"
+        "Note",
+        "Reply",
     ]
 
 

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -155,6 +155,9 @@ class ShotgridListener:
             1) Events of Projects with "AYON Auto Sync" enabled.
             2) Events on entities and type for entities we track.
 
+        Further we need to handle Replies differently as they don't have
+        a project field, but inherit the project from their parent Note.
+
         Args:
             sg_projects (list): List of Shotgrid Project IDs.
 
@@ -166,19 +169,55 @@ class ShotgridListener:
         if not sg_projects:
             return []
 
-        filters.append(["project", "in", sg_projects])
+        # Get supported event types first
+        sg_event_types = self._get_supported_event_types()
+        if not sg_event_types:
+            return []
 
-        if sg_event_types := self._get_supported_event_types():
-            filters.append(["event_type", "in", sg_event_types])
+        # Split Reply events from other events
+        reply_events = [et for et in sg_event_types if et.startswith("Shotgun_Reply_")]
+        other_events = [et for et in sg_event_types if not et.startswith("Shotgun_Reply_")]
+
+        project_filter = ["project", "in", sg_projects]
+
+        if reply_events and other_events:
+            filters.append({
+                "filter_operator": "any",
+                "filters": [
+                    # Regular events with project filter
+                    {
+                        "filter_operator": "all",
+                        "filters": [
+                            project_filter,
+                            ["event_type", "in", other_events]
+                        ]
+                    },
+                    # Reply events without project filter (they inherit from parent)
+                    ["event_type", "in", reply_events]
+                ]
+            })
+        elif reply_events:
+            # Only Reply events
+            filters.append(["event_type", "in", reply_events])
+        elif other_events:
+            # Only regular events
+            filters.append(project_filter)
+            filters.append(["event_type", "in", other_events])
 
         return filters
 
     def _get_supported_event_types(self) -> list[str]:
         sg_event_types = []
         for entity_type in self.sg_enabled_entities:
-            sg_event_types.extend(
-                event_name.format(entity_type) for event_name in SG_EVENT_TYPES
-            )
+            if entity_type == "Reply":
+                sg_event_types.extend(
+                    event_name.format(entity_type) for event_name in SG_EVENT_TYPES
+                    if not event_name.endswith("Retirement")
+                )
+            else:
+                sg_event_types.extend(
+                    event_name.format(entity_type) for event_name in SG_EVENT_TYPES
+                )
         return sg_event_types
 
     def _find_last_event_id(self):
@@ -411,9 +450,29 @@ class ShotgridListener:
         payload["created_at"] = payload["created_at"].isoformat()
 
         payload_meta = payload.get("meta", {})
+        self.log.debug(f"{payload_meta = }")
         if payload_meta.get("entity_type", "Undefined") == "Project":
             project_name = payload.get("entity", {}).get("name", "Undefined")
             project_id = payload.get("entity", {}).get("id", "Undefined")
+        elif payload_meta.get("entity_type", "Undefined") == "Reply":
+            if payload_meta.get("attribute_name") == "retirement_date":
+                self.log.warning("Deleting Replies in AYON is not yet supported.")
+                return
+            reply_id = payload_meta.get("entity_id")
+            reply = self.sg_session.find_one(
+                "Reply",
+                [["id", "is", reply_id]],
+                ["entity"]
+            )
+            schema = self.sg_session.schema_field_read("Note")
+            note = self.sg_session.find_one(
+                "Note",
+                [["id", "is", reply.get("entity", {}).get("id")]],
+                list(schema.keys())
+            )
+            self.log.debug(f"{note = }")
+            project_id = note.get("project", {}).get("id", None)
+            project_name = note.get("project", {}).get("name", None)
         else:
             project_name = payload.get("project", {}).get("name", "Undefined")
             project_id = payload.get("project", {}).get("id", "Undefined")

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -153,7 +153,7 @@ def _sg_to_ay_dict(
         ay_entity_type = "version"
         name = slugify_string(sg_entity["code"], min_length=0)
         label = sg_entity["code"]
-    elif sg_entity["type"] == "Note":
+    elif sg_entity["type"] in ["Note", "Reply"]:
         ay_entity_type = "comment"
         content = sg_entity["content"] or ""
         name = slugify_string(content, min_length=0)
@@ -1664,7 +1664,7 @@ def get_sg_user_id(ayon_username: str) -> [int]:
 def handle_comment(sg_ay_dict, sg_session, entity_hub):
     """Transforms content and links from SG to matching AYON structures."""
     sg_note_id = sg_ay_dict["attribs"][SHOTGRID_ID_ATTRIB]
-    sg_note, sg_note_id = _get_sg_note(sg_note_id, sg_session)
+    sg_note, sg_note_id = _get_sg_chat_msg(sg_note_id, sg_session, "Note")
 
     if not sg_note:
         log.warning(f"Couldn't find note '{sg_note_id}'")
@@ -1713,6 +1713,55 @@ def handle_comment(sg_ay_dict, sg_session, entity_hub):
             CUST_FIELD_CODE_ID: ay_activity_id
         }
     )
+
+def handle_reply(sg_ay_dict, sg_session, entity_hub):
+    sg_note_id = sg_ay_dict["attribs"][SHOTGRID_ID_ATTRIB]
+    sg_reply, sg_reply_id = _get_sg_chat_msg(sg_note_id, sg_session, "Reply")
+    parent_note, parent_note_id = _get_sg_chat_msg(sg_reply["entity"]["id"], sg_session, "Note")
+    ay_parent_entity = _get_sg_note_parent_entity(entity_hub, parent_note, sg_session)
+
+    log.debug(f"{sg_reply = }")
+    log.debug(f"{parent_note = }")
+
+    # build the content citing the parent note
+    content = f"> {parent_note['content']}\n\n{sg_reply['content']}"
+
+    project_name = entity_hub.project_name
+    ayon_user_name = _get_ayon_user_name(sg_reply["user"])
+
+    # get sg reply id from sg
+    ayon_comment = None
+    ay_comment_activities = ayon_api.get_activities(
+        project_name,
+        activity_types=["comment"],
+        entity_ids=[ay_parent_entity["id"]],
+        fields=["body", "activityId", "activityData"]
+    )
+    # iterate all comments in AYON on the sg_parent_note parent entity
+    # and find the one with matching sg_reply id in the content
+    for ay_cmt in list(ay_comment_activities):
+        log.debug(f"{ay_cmt = }")
+        if int(ay_cmt["activityData"].get("sg_note_id", -1)) == int(sg_reply_id):
+            ayon_comment = ay_cmt
+            break
+
+    if not ayon_comment:
+        _ = _add_comment(
+            sg_session,
+            project_name,
+            ay_parent_entity["id"],
+            ay_parent_entity["entity_type"],
+            ayon_user_name,
+            content,
+            sg_reply,
+        )
+    else:
+        ayon_api.update_activity(
+            project_name,
+            ayon_comment["activityId"],
+            body=content,
+            data=ayon_comment["activityData"],
+        )
 
 
 def _update_comment(
@@ -1785,20 +1834,15 @@ def _update_comment(
     return ay_activity_id
 
 
-def _get_sg_note(sg_note_id, sg_session):
-    """Gets detail information about SG note wih SG id."""
+def _get_sg_chat_msg(sg_note_id, sg_session, sg_msg_type):
+    """Gets detail information about SG note/reply wih SG id."""
+    schema = sg_session.schema_field_read(sg_msg_type)
+    all_fields = list(schema.keys())
+    log.debug(f"{all_fields = }")
     sg_note = sg_session.find_one(
-        "Note",
+        sg_msg_type,
         [["id", "is", int(sg_note_id)]],
-        fields=[
-            "id",
-            "content",
-            "sg_ayon_id",
-            "user",
-            "note_links",
-            "addressings_to",
-            "attachments"
-        ]
+        fields=all_fields
     )
     return sg_note, sg_note_id
 
@@ -1878,7 +1922,7 @@ def _get_sg_note_parent_entity(entity_hub, sg_note, sg_session):
 def _get_content_with_notifications(sg_note):
     """Translates SG 'addressings_to' to AYON @ mentions."""
     content = sg_note["content"]
-    for sg_user in sg_note["addressings_to"]:
+    for sg_user in sg_note.get("addressings_to", []):
         if sg_user["type"] != "HumanUser":
             log.warning(f"Cannot create notes for non humans "
                         f"- {sg_user['type']}")


### PR DESCRIPTION
adresses https://github.com/ynput/ayon-shotgrid/issues/199

## Changelog Description
My take on supporting syncing of `Reply` entities SG->AYON. 

## Additional review information
`Reply` is a very special entity type in SG that's not as easy to work with. It doesn't save the project it's connected and also doesn't allow for new custom attributes (like `sg_ayon_id`).
For that reason i didn't find a way to support deleting a reply in AYON when it is deleted in SG.

## Testing notes:
1. build/upload new server settings
2. configure `Reply` as supported entity type in compatibility settings
3. build/run containers
4. write/update a reply in SG
