### PR TITLE
Sync comment only if enabled in compatibility settings

### DIFF
--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -177,7 +177,7 @@ class ShotgridTransmitter:
                 # Run comments sync
                 now_time = arrow.utcnow()
                 sec_diff = (now_time - last_comments_sync).total_seconds()
-                if sec_diff > COMMENTS_SYNC_INTERVAL and "Note" in self.sg_enabled_entities:
+                if sec_diff > COMMENTS_SYNC_INTERVAL:
                     self._sync_comments()
 
                 # enrolling only events which were not created by any
@@ -297,6 +297,10 @@ class ShotgridTransmitter:
 
         if activities_after_date is None:
             activities_after_date = now - timedelta(days=5)
+
+        if "Note" not in self.sg_enabled_entities:
+            self.log.warning("Skipping comments sync, 'Note' entity is not enabled.")
+            return
 
         response = ayon_api.dispatch_event(
             SHOTGRID_COMMENTS_TOPIC,

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -295,10 +295,6 @@ class ShotgridTransmitter:
         if activities_after_date is None:
             activities_after_date = now - timedelta(days=5)
 
-        if "Note" not in self.sg_enabled_entities:
-            self.log.warning("Skipping comments sync, 'Note' entity is not enabled.")
-            return
-
         response = ayon_api.dispatch_event(
             SHOTGRID_COMMENTS_TOPIC,
             description=(
@@ -367,10 +363,10 @@ class ShotgridTransmitter:
     def _get_last_finished_event(self):
         """Finds last successful run of comments synching to SG."""
         finished_events = list(ayon_api.get_events(
-            topics={SHOTGRID_COMMENTS_TOPIC},
-            statuses={"finished"},
-            limit=1,
-            order=ayon_api.SortOrder.descending,
+                topics={SHOTGRID_COMMENTS_TOPIC},
+                statuses={"finished"},
+                limit=1,
+                order=ayon_api.SortOrder.descending,
         ))
         for event in finished_events:
             return event

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -177,7 +177,7 @@ class ShotgridTransmitter:
                 # Run comments sync
                 now_time = arrow.utcnow()
                 sec_diff = (now_time - last_comments_sync).total_seconds()
-                if sec_diff > COMMENTS_SYNC_INTERVAL:
+                if sec_diff > COMMENTS_SYNC_INTERVAL and "Note" in self.sg_enabled_entities:
                     self._sync_comments()
 
                 # enrolling only events which were not created by any

--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -10,6 +10,7 @@ import time
 from datetime import datetime, timezone, timedelta
 import socket
 import traceback
+from typing import AnyStr
 
 import arrow
 
@@ -375,7 +376,11 @@ class ShotgridTransmitter:
             return event
         return None
 
-    def _prepare_custom_attribs_map(self, custom_attribs_map):
+    def _prepare_custom_attribs_map(
+        self,
+        custom_attribs_map: dict[str, str]
+    ) -> dict[str, str]:
+        """Returns dict of synced AYON attributes to SG attribute."""
         custom_attribs = {
             attr["ayon"]: attr["sg"]
             for attr in custom_attribs_map
@@ -389,7 +394,11 @@ class ShotgridTransmitter:
 
         return custom_attribs
 
-    def _prepare_custom_attribs_types(self, custom_attribs_map):
+    def _prepare_custom_attribs_types(
+        self,
+        custom_attribs_map: dict[str, str]
+    ) -> dict[str, tuple[str, str]]:
+        """Returns dict of tuples with data types of synced attributes."""
         return {
             attr["sg"]: (attr["type"], attr["scope"])
             for attr in custom_attribs_map


### PR DESCRIPTION
## Changelog Description
This PR provides project based control of comments synchronization and more granular support for synched custom attributes (per project).


## Testing notes:
1. enable/disable Notes in your synchronized project `ayon+settings://shotgrid/compatibility_settings/shotgrid_enabled_entities`
2. experiment also with project based `ayon+settings://shotgrid/compatibility_settings/custom_attribs_map`
