### PR TITLE
Fix: error when sg_entity couldn't be created

### DIFF
--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
@@ -77,15 +77,18 @@ def create_sg_entity_from_ayon_event(
 
     sg_entity = None
 
-    if sg_id and not isinstance(sg_id, int):
-        log.warning(
-            f"Skip SG entity processing from AYON '{ay_entity}'. "
-            f"AYON entity defines an invalid non-integer sg_id '{sg_id}'."
-        )
-        return ay_entity
+    if sg_id is not None:
+        try:
+            sg_id = int(sg_id)
+        except (ValueError, TypeError):
+            log.warning(
+                f"Skip SG entity processing from AYON '{ay_entity}'. "
+                f"AYON entity defines an invalid non-integer sg_id '{sg_id}'."
+            )
+            return ay_entity
 
     if sg_id and sg_type:
-        sg_entity = sg_session.find_one(sg_type, [["id", "is", int(sg_id)]])
+        sg_entity = sg_session.find_one(sg_type, [["id", "is", sg_id]])
 
     if sg_entity:
         log.warning(f"Entity {sg_entity} already exists in Shotgrid!")


### PR DESCRIPTION
## Changelog Description
It is expected that `create_sg_entity_from_ayon_event` will always return source `ay_entity` even if Shotgrid entity couldn't be created.

## Additional review information
Solves:
```
Traceback (most recent call last):
  File "/service/transmitter/transmitter.py", line 223, in start_processing
    hub.react_to_ayon_event(source_event)
  File "/service/ayon_shotgrid_hub/init.py", line 438, in react_to_ayon_event
    update_sg_entity_from_ayon_event(
  File "/service/ayon_shotgrid_hub/update_from_ayon.py", line 251, in update_sg_entity_from_ayon_event
    sg_id = ay_entity.attribs.get("shotgridId")
            ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'attribs'
```
It should return `ay_entity` which is used to query updated/none `shotgridId`.

In this case it is triggered if Task should be synchronized to SG, but its parent has non integral value in `shotgridId` (not yet sure how this could happen). This doesn't solve original problem, but it helps debugging and manual mitigation.

## Testing notes:
1. to replicate mangle `shotgridId` to any string value
<img width="2017" height="630" alt="image" src="https://github.com/user-attachments/assets/7a72a754-cc21-4887-9b57-de1ac3885d39" />


