### PR TITLE
Fix: usage of empty return from get_sg_entity_as_ay_dict

### DIFF
--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -92,7 +92,6 @@ def create_ay_entity_from_sg_event(
 
     extra_fields = [sg_parent_field]
 
-
     sg_ay_dict = get_sg_entity_as_ay_dict(
         sg_session,
         sg_event["entity_type"],
@@ -103,17 +102,17 @@ def create_ay_entity_from_sg_event(
         extra_fields=extra_fields,
     )
 
-    if sg_ay_dict["type"].lower() == "comment":
-        # SG note as AYON comment creation is
-        # handled by update_ayon_entity_from_sg_event
-        return
-
     log.debug(f"ShotGrid Entity as AYON dict: {sg_ay_dict}")
     if not sg_ay_dict:
         log.warning(
             f"Entity {sg_event['entity_type']} <{sg_event['entity_id']}> "
             "no longer exists in ShotGrid, aborting..."
         )
+        return
+
+    if sg_ay_dict["type"].lower() == "comment":
+        # SG note as AYON comment creation is
+        # handled by update_ayon_entity_from_sg_event
         return
 
     ayon_id_stored_in_sg = sg_ay_dict["data"].get(CUST_FIELD_CODE_ID)


### PR DESCRIPTION
## Changelog Description
Solves:
```
Traceback (most recent call last):
  File "/service/processor/processor.py", line 281, in start_processing
    handler.process_event(
  File "/service/processor/handlers/shotgrid_event.py", line 37, in process_event
    hub.react_to_shotgrid_event(sg_payload["meta"])
  File "/service/ayon_shotgrid_hub/init.py", line 344, in react_to_shotgrid_event
    create_ay_entity_from_sg_event(
  File "/service/ayon_shotgrid_hub/update_from_shotgrid.py", line 106, in create_ay_entity_from_sg_event
    if sg_ay_dict["type"].lower() == "comment":
       ~~^^^^^^^^
KeyError: 'type'
```

## Testing notes:
1. Most likely it could only happen if SG entity was deleted before its event got a chance to be processed.
2. with enabled auto sync, create entity in SG that should be synchronized to AYON, but delete it immediately
