### PR TITLE
Add sender filter to transmitter service

### DIFF
--- a/services/transmitter/transmitter/transmitter.py
+++ b/services/transmitter/transmitter/transmitter.py
@@ -406,5 +406,7 @@ class ShotgridTransmitter:
 
 def service_main():
     ayon_api.init_service()
+    ayon_api.set_sender_type("shotgrid")
+
     shotgrid_transmitter = ShotgridTransmitter()
     sys.exit(shotgrid_transmitter.start_processing())


### PR DESCRIPTION
## Changelog Description
Added a sender_type filter to prevent the service from reacting to changes triggered by the synchronization service itself.

Previously, this feedback loop caused newly synchronized task names in ShotGrid to be cleared unexpectedly.

## Additional review information
The current ayon_api.EntityHub generates a reset 'label' change if the label is identical to the 'name'. This change is propagated to AYON when an entity is updated with its shotgridId and shotgridType.

Consequently, this triggers unnecessary entity.task.attrib_changed and entity.task.label_changed events, which are then picked up by the transmitter. This PR implements a filter in the transmitter to ignore these self-triggered changes, mirroring the logic already present in the processor.

Note: A separate update for ayon-python-api is planned to properly handle scenarios where the label should intentionally remain empty.

## Testing notes:
1. start sync services
2. create task in AYON
3. check that task in SG has a name
