### PR TITLE
BugFix Sync with 0 value

### DIFF
--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1373,7 +1373,7 @@ def update_ay_entity_custom_attributes(
     for ay_attrib, _ in custom_attribs_map.items():
         if values_to_update and ay_attrib not in values_to_update:
             continue
-         
+
         attrib_value = sg_ay_dict["attribs"].get(ay_attrib, sg_ay_dict.get(ay_attrib, None))
 
         if attrib_value is None:

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -190,10 +190,10 @@ def _sg_to_ay_dict(
 
     if custom_attribs_map:
         for ay_attrib, sg_attrib in custom_attribs_map.items():
-            sg_value = (sg_entity.get(f"sg_{sg_attrib}")
-                        or sg_entity.get(sg_attrib))
 
             # If no value in SG entity skip
+            sg_value = sg_entity.get(f"sg_{sg_attrib}", sg_entity.get(sg_attrib, None))
+
             if sg_value is None:
                 continue
 
@@ -1373,8 +1373,9 @@ def update_ay_entity_custom_attributes(
     for ay_attrib, _ in custom_attribs_map.items():
         if values_to_update and ay_attrib not in values_to_update:
             continue
+         
+        attrib_value = sg_ay_dict["attribs"].get(ay_attrib, sg_ay_dict.get(ay_attrib, None))
 
-        attrib_value = sg_ay_dict["attribs"].get(ay_attrib) or sg_ay_dict.get(ay_attrib)
         if attrib_value is None:
             continue
 


### PR DESCRIPTION
## Changelog Description
There is an issue when trying  to sync a 0 value from flow to ayon.
This is because of an or statement in the code

## Additional review information
```python
>>> print(None or 0)
0
>>> print(0 or None)
None
```

## Testing notes:
In order to reproduce, just try to change a field in sg to 0.
