### PR TITLE
Services: Use uv for service build

### DIFF
--- a/services/.dockerignore
+++ b/services/.dockerignore
@@ -1,0 +1,11 @@
+**/__pycache__
+**/*.pyc
+**/*.pyo
+**/*.pyd
+.git
+.gitignore
+.idea
+.vscode
+venv
+.venv
+*.zip

--- a/services/leecher/Dockerfile
+++ b/services/leecher/Dockerfile
@@ -1,26 +1,34 @@
 # In order for this Dockerfile to work it needs to be built from the `services` directory
+FROM python:3.11-alpine3.18 AS builder
+
+# Install build dependencies
+RUN apk add --update --no-cache git curl build-base libffi-dev
+
+# Download and install uv
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
+RUN sh /uv-installer.sh && rm /uv-installer.sh
+ENV PATH="/root/.local/bin/:$PATH"
+
+# Create Working directory `/service` and copy `leecher`
+WORKDIR /service
+COPY leecher/pyproject.toml /service/pyproject.toml
+
+# Sync dependencies using uv to a virtual environment
+RUN uv venv --python $(which python) && \
+    uv pip install -r pyproject.toml
+
+# Final stage
 FROM python:3.11-alpine3.18
 ENV PYTHONUNBUFFERED=1
 
-# Install python/pip
-RUN apk add --update --no-cache git curl build-base libffi-dev
-RUN python -m ensurepip
-RUN python -m pip install --no-cache --upgrade pip setuptools poetry pip-autoremove && ln -sf pip3 /usr/bin/pip
+# Copy the virtual environment from the builder
+COPY --from=builder /service/.venv /venv
+ENV PATH="/venv/bin:$PATH"
 
-# Create Working directory `/service` and copy `leecher`
-RUN mkdir /service
-COPY leecher/pyproject.toml /service/pyproject.toml
+# Create Working directory `/service` and copy the code
 WORKDIR /service
-
-# Install dependencies with poetry
-RUN poetry config virtualenvs.create false
-RUN poetry install --no-interaction --no-ansi --only main
-
-# Remove unnecessary packages to make the image smaller
-RUN apk del git curl build-base libffi-dev
-RUN python -m pip cache purge
-RUN pip-autoremove -y setuptools poetry
-RUN python -m pip uninstall -y pip pip-autoremove
+COPY leecher/leecher /service/leecher
+COPY shotgrid_common /service
 
 # Create a group and user: ayonuser
 RUN addgroup -S ayonuser && adduser -SH ayonuser -G ayonuser
@@ -28,11 +36,7 @@ RUN addgroup -S ayonuser && adduser -SH ayonuser -G ayonuser
 RUN chown ayonuser:ayonuser -R /service
 RUN chmod 777 -R /service
 
-COPY leecher/leecher /service/leecher
-COPY shotgrid_common /service
-
 # Tell docker that all future commands should run as the appuser user
 USER ayonuser
 
 CMD ["python", "-m", "leecher"]
-

--- a/services/leecher/pyproject.toml
+++ b/services/leecher/pyproject.toml
@@ -1,18 +1,15 @@
-[tool.poetry]
+[project]
 name = "shotgrid-leecher"
 version = "0.6.17+dev"
 description = "Shotgrid Integration for AYON"
-authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
-package-mode = false
+authors = [
+    {name = "Ynput s.r.o.", email = "info@ynput.io"}
+]
+requires-python = ">=3.11"
+dependencies = [
+    "ayon_python_api>=1.2.7",
+    "shotgun-api3"
+]
 
-[tool.poetry.dependencies]
-python = ">=3.10,<4.0"
-ayon_python_api = "^1.2.7"
-shotgun-api3 = "*"
-
-[tool.poetry.dev-dependencies]
-pytest = "^5.2"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[tool.uv]
+package = false

--- a/services/processor/Dockerfile
+++ b/services/processor/Dockerfile
@@ -1,35 +1,40 @@
 # In order for this Dockerfile to work it needs to be built from the `services` directory
+FROM python:3.11-alpine3.18 AS builder
+
+# Install build dependencies
+RUN apk add --update --no-cache git curl build-base libffi-dev
+
+# Download and install uv
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
+RUN sh /uv-installer.sh && rm /uv-installer.sh
+ENV PATH="/root/.local/bin/:$PATH"
+
+# Create Working directory `/service` and copy `processor`
+WORKDIR /service
+COPY processor/pyproject.toml /service/pyproject.toml
+
+# Sync dependencies using uv to a virtual environment
+RUN uv venv --python $(which python) && \
+    uv pip install -r pyproject.toml
+
+# Final stage
 FROM python:3.11-alpine3.18
 ENV PYTHONUNBUFFERED=1
 
-# Install python/pip
-RUN apk add --update --no-cache git curl build-base libffi-dev
-RUN python -m ensurepip
-RUN python -m pip install --no-cache --upgrade pip setuptools poetry pip-autoremove && ln -sf pip3 /usr/bin/pip
+# Copy the virtual environment from the builder
+COPY --from=builder /service/.venv /venv
+ENV PATH="/venv/bin:$PATH"
 
-# Create Working directory `/service` and copy `processor`
-RUN mkdir /service
-COPY processor/pyproject.toml /service/pyproject.toml
+# Create Working directory `/service` and copy the code
 WORKDIR /service
-
-# Install dependencies with poetry
-RUN poetry config virtualenvs.create false
-RUN poetry install --no-interaction --no-ansi --only main
-
-# Remove unnecessary packages to make the image smaller
-RUN apk del git curl build-base libffi-dev
-RUN python -m pip cache purge
-RUN pip-autoremove -y setuptools poetry
-RUN python -m pip uninstall -y pip pip-autoremove
+COPY processor/processor /service/processor
+COPY shotgrid_common /service
 
 # Create a group and user: ayonuser
 RUN addgroup -S ayonuser && adduser -SH ayonuser -G ayonuser
 
 RUN chown ayonuser:ayonuser -R /service
 RUN chmod 777 -R /service
-
-COPY processor/processor /service/processor
-COPY shotgrid_common /service
 
 # Tell docker that all future commands should run as the appuser user
 USER ayonuser

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -1,18 +1,15 @@
-[tool.poetry]
+[project]
 name = "shotgrid-processor"
 version = "0.6.17+dev"
 description = "Shotgrid Integration for AYON"
-authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
-package-mode = false
+authors = [
+    {name = "Ynput s.r.o.", email = "info@ynput.io"}
+]
+requires-python = ">=3.11"
+dependencies = [
+    "ayon_python_api>=1.2.7",
+    "shotgun-api3"
+]
 
-[tool.poetry.dependencies]
-python = ">=3.10,<4.0"
-ayon_python_api = "^1.2.7"
-shotgun-api3 = "*"
-
-[tool.poetry.dev-dependencies]
-pytest = "^5.2"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[tool.uv]
+package = false

--- a/services/transmitter/Dockerfile
+++ b/services/transmitter/Dockerfile
@@ -1,35 +1,40 @@
 # In order for this Dockerfile to work it needs to be built from the `services` directory
+FROM python:3.11-alpine3.18 AS builder
+
+# Install build dependencies
+RUN apk add --update --no-cache git curl build-base libffi-dev
+
+# Download and install uv
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
+RUN sh /uv-installer.sh && rm /uv-installer.sh
+ENV PATH="/root/.local/bin/:$PATH"
+
+# Create Working directory `/service` and copy `transmitter`
+WORKDIR /service
+COPY transmitter/pyproject.toml /service/pyproject.toml
+
+# Sync dependencies using uv to a virtual environment
+RUN uv venv --python $(which python) && \
+    uv pip install -r pyproject.toml
+
+# Final stage
 FROM python:3.11-alpine3.18
 ENV PYTHONUNBUFFERED=1
 
-# Install python/pip
-RUN apk add --update --no-cache git curl build-base libffi-dev
-RUN python -m ensurepip
-RUN python -m pip install --no-cache --upgrade pip setuptools poetry pip-autoremove && ln -sf pip3 /usr/bin/pip
+# Copy the virtual environment from the builder
+COPY --from=builder /service/.venv /venv
+ENV PATH="/venv/bin:$PATH"
 
-# Create Working directory `/service` and copy `transmitter`
-RUN mkdir /service
-COPY transmitter/pyproject.toml /service/pyproject.toml
+# Create Working directory `/service` and copy the code
 WORKDIR /service
-
-# Install dependencies with poetry
-RUN poetry config virtualenvs.create false
-RUN poetry install --no-interaction --no-ansi --only main
-
-# Remove unnecessary packages to make the image smaller
-RUN apk del git curl build-base libffi-dev
-RUN python -m pip cache purge
-RUN pip-autoremove -y setuptools poetry
-RUN python -m pip uninstall -y pip pip-autoremove
+COPY transmitter/transmitter /service/transmitter
+COPY shotgrid_common /service
 
 # Create a group and user: ayonuser
 RUN addgroup -S ayonuser && adduser -SH ayonuser -G ayonuser
 
 RUN chown ayonuser:ayonuser -R /service
 RUN chmod 777 -R /service
-
-COPY transmitter/transmitter /service/transmitter
-COPY shotgrid_common /service
 
 # Tell docker that all future commands should run as the appuser user
 USER ayonuser

--- a/services/transmitter/pyproject.toml
+++ b/services/transmitter/pyproject.toml
@@ -1,19 +1,16 @@
-[tool.poetry]
+[project]
 name = "shotgrid-transmitter"
 version = "0.6.17+dev"
 description = "Shotgrid Integration for AYON"
-authors = ["Oscar Domingo <oscar.domingo@ynput.com>"]
-package-mode = false
+authors = [
+    {name = "Ynput s.r.o.", email = "info@ynput.io"}
+]
+requires-python = ">=3.11"
+dependencies = [
+    "arrow",
+    "ayon_python_api>=1.2.7",
+    "shotgun-api3"
+]
 
-[tool.poetry.dependencies]
-python = ">=3.10,<4.0"
-arrow = "*"
-ayon_python_api = "^1.2.7"
-shotgun-api3 = "*"
-
-[tool.poetry.dev-dependencies]
-pytest = "^5.2"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[tool.uv]
+package = false


### PR DESCRIPTION
## Changelog Description
Build venv for services usign uv.

## Additional review information
Docker build is separated into 2 parts, builder where dependencies are installed using uv. Second is the "running" image where the venv is used.

This fixes issues with docker build (https://github.com/ynput/ayon-shotgrid/actions/runs/23429443560/job/68151844438).

```
#17 [12/18] RUN pip-autoremove -y setuptools poetry
#17 0.163 Traceback (most recent call last):
#17 0.163   File "/usr/local/bin/pip-autoremove", line 5, in <module>
#17 0.163     from pip_autoremove import main
#17 0.163   File "/usr/local/bin/pip_autoremove.py", line 9, in <module>
#17 0.163     from pkg_resources import (
#17 0.163 ModuleNotFoundError: No module named 'pkg_resources'
#17 ERROR: process "/bin/sh -c pip-autoremove -y setuptools poetry" did not complete successfully: exit code: 1
------
 > [12/18] RUN pip-autoremove -y setuptools poetry:
0.163 Traceback (most recent call last):
0.163   File "/usr/local/bin/pip-autoremove", line 5, in <module>
0.163     from pip_autoremove import main
0.163   File "/usr/local/bin/pip_autoremove.py", line 9, in <module>
0.163     from pkg_resources import (
0.163 ModuleNotFoundError: No module named 'pkg_resources'
```

## Testing notes:
1. Docker images can be build and can be used with ash worker.
