### PR TITLE
YN-0699 Fix playlist support with manual changes

### DIFF
--- a/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_ayon_hierarchy_in_shotgrid.py
@@ -1,3 +1,4 @@
+import json
 import collections
 import shotgun_api3
 from typing import Dict, List, Union, Any
@@ -25,6 +26,8 @@ from utils import (
 )
 
 from utils import get_logger
+
+from .update_from_ayon import sync_sg_playlist_from_ayon_event
 
 
 log = get_logger(__file__)
@@ -332,6 +335,36 @@ def match_ayon_hierarchy_in_shotgrid(
 
     # committing changes on project entity
     entity_hub.commit_changes()
+
+    # Sync AYON playlists
+    entity_lists = ayon_api.get_entity_lists(
+        entity_hub.project_name,
+        fields=["id", "label", "entityType", "allAttrib"],
+    )
+    for entity_list in entity_lists:
+        if entity_list.get("entityType") != "version":
+            log.debug(f"Entity list {entity_list['id']} is not a version entity.")
+            continue
+
+        all_attrib = entity_list.get("allAttrib")
+        if isinstance(all_attrib, str):
+            all_attrib = json.loads(all_attrib)
+        sg_id = (all_attrib or {}).get("sg_id")
+        topic = "entity_list.changed" if sg_id else "entity_list.created"
+
+        sync_sg_playlist_from_ayon_event(
+            {
+                "topic": topic,
+                "summary": {
+                    "id": entity_list["id"],
+                    "entity_type": "version",
+                    "label": entity_list["label"],
+                },
+            },
+            sg_session,
+            entity_hub,
+            sg_project,
+        )
 
 
 def _add_items_to_queue(

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -269,11 +269,6 @@ def _update_ay_entity(
             ay_project=entity_hub.project_entity
         )
 
-    # If playlist update version content here
-    if sg_ay_dict["type"].lower() == "playlist":
-        # TODO: update playlist content here
-        pass
-
     return True
 
 

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -95,14 +95,16 @@ def match_shotgrid_hierarchy_in_ayon(
             continue
 
         if sg_ay_dict["type"].lower() == "entity_list":
-            event_type = (
-                "attribute_change"
-                if sg_ay_dict["data"].get("sg_ayon_id")
-                else "new_entity"
+            ayon_list_id = sg_ay_dict["data"].get(CUST_FIELD_CODE_ID)
+            ay_list_exists = ayon_list_id and any(
+                lst["id"] == ayon_list_id
+                for lst in ayon_api.get_entity_lists(
+                    entity_hub.project_name, fields=["id"]
+                )
             )
             sync_ay_entity_list_from_sg_event(
                 {
-                    "type": event_type,
+                    "type": "attribute_change" if ay_list_exists else "new_entity",
                     "entity_id": sg_entity_id,
                     "attribute_name": "versions",
                 },

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -268,8 +268,7 @@ def _update_ay_entity(
             custom_attribs_map,
             ay_project=entity_hub.project_entity
         )
-
-    return True
+        return True
 
 
 def _update_sg_entity(

--- a/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/match_shotgrid_hierarchy_in_ayon.py
@@ -22,6 +22,8 @@ from utils import (
     update_ay_entity_custom_attributes, handle_comment,
 )
 
+from .update_from_shotgrid import sync_ay_entity_list_from_sg_event
+
 from utils import get_logger
 
 
@@ -90,6 +92,23 @@ def match_shotgrid_hierarchy_in_ayon(
 
         if sg_ay_dict["type"].lower() == "comment":
             handle_comment(sg_ay_dict, sg_session, entity_hub)
+            continue
+
+        if sg_ay_dict["type"].lower() == "entity_list":
+            event_type = (
+                "attribute_change"
+                if sg_ay_dict["data"].get("sg_ayon_id")
+                else "new_entity"
+            )
+            sync_ay_entity_list_from_sg_event(
+                {
+                    "type": event_type,
+                    "entity_id": sg_entity_id,
+                    "attribute_name": "versions",
+                },
+                sg_project,
+                sg_session,
+            )
             continue
 
         shotgrid_type = sg_ay_dict["attribs"].get(SHOTGRID_TYPE_ATTRIB)
@@ -247,7 +266,13 @@ def _update_ay_entity(
             custom_attribs_map,
             ay_project=entity_hub.project_entity
         )
-        return True
+
+    # If playlist update version content here
+    if sg_ay_dict["type"].lower() == "playlist":
+        # TODO: update playlist content here
+        pass
+
+    return True
 
 
 def _update_sg_entity(

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
@@ -185,6 +185,7 @@ def sync_sg_playlist_from_ayon_event(
     except Exception:
         log.info("EntityList couldn't be fetched. We're probably deleting the list.")
 
+    sg_versions = []
     if entity_list:
         version_ids = [entity["entityId"] for entity in entity_list["items"]]
         ay_versions = ayon_api.get_versions(
@@ -200,6 +201,9 @@ def sync_sg_playlist_from_ayon_event(
 
     match ayon_event["topic"]:
         case "entity_list.created":
+            if not entity_list:
+                log.error("EntityList not found, cannot create SG Playlist.")
+                return
             log.info(f"Creating new SG Playlist from AYON EntityList {entity_list['label']}")
             playlist = sg_session.create(
                 "Playlist",
@@ -224,6 +228,9 @@ def sync_sg_playlist_from_ayon_event(
                 }
             )
         case "entity_list.changed":
+            if not entity_list:
+                log.error("EntityList not found, cannot update SG Playlist.")
+                return
             if not entity_list["attrib"].get("sg_id"):
                 log.error("SG Playlist ID not found on AYON EntityList")
 

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -229,18 +229,18 @@ def sync_ay_entity_list_from_sg_event(
         ["id", "code", "versions", "sg_ayon_id", "locked"]
     )
 
+    ay_version_items = []
     if playlist:
-        # get ayon_id for all sg versions
-        ay_version_items = []
-        for idx, version in enumerate(playlist.get("versions", [])):
-            sg_version = sg_session.find_one(
+        # get ayon_id for all sg versions in a single batched query
+        version_ids = [v["id"] for v in playlist.get("versions", [])]
+        if version_ids:
+            for sg_version in sg_session.find(
                 "Version",
-                [["id", "is", version["id"]]],
+                [["id", "in", version_ids]],
                 ["sg_ayon_id"]
-            )
-            if sg_version.get("sg_ayon_id"):
-                item = {"entityId": sg_version["sg_ayon_id"]}
-                ay_version_items.append(item)
+            ):
+                if sg_version.get("sg_ayon_id"):
+                    ay_version_items.append({"entityId": sg_version["sg_ayon_id"]})
 
     match sg_event_meta["type"]:
         case "new_entity":

--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_shotgrid.py
@@ -287,7 +287,7 @@ def sync_ay_entity_list_from_sg_event(
             log.info(f"\t- label = {playlist['code']}")
             log.info(f"\t- active = {not playlist.get('locked', False)}")
             ayon_api.raw_patch(    # doesn't respect 'active' attribute or support adding versions
-                f"/projects/{sg_project['name']}/lists",
+                f"/projects/{sg_project['name']}/lists/{playlist['sg_ayon_id']}",
                 json={
                     "project_name": sg_project["name"],
                     "entity_type": "version",
@@ -295,13 +295,19 @@ def sync_ay_entity_list_from_sg_event(
                     "attrib": {"sg_id": playlist["id"]},
                 }
             )
-            ayon_api.raw_patch(    # so i add version here
-                f"/projects/{sg_project['name']}/lists/{playlist['sg_ayon_id']}/items",
-                json={
-                    "items": ay_version_items,
-                    "mode": "replace",
-                }
-            )
+            if ay_version_items:
+                ayon_api.raw_patch(
+                    f"/projects/{sg_project['name']}/lists/{playlist['sg_ayon_id']}/items",
+                    json={"items": ay_version_items, "mode": "replace"},
+                )
+
+            # Empty list, delete all items.
+            # raw_patch or items=[] and mode="replace" does not clean the list.
+            else:
+                current = ayon_api.get_entity_list_rest(sg_project["name"], playlist["sg_ayon_id"])
+                for item in current.get("items", []):
+                    ayon_api.delete_entity_list_item(sg_project["name"], playlist["sg_ayon_id"], item["id"])
+
             ayon_api.update_entity_list(    # and update active attrib here
                 project_name=sg_project["name"],
                 list_id=playlist["sg_ayon_id"],

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1503,6 +1503,11 @@ def create_new_ayon_entity(
             attribs=sg_ay_dict["attribs"],
             data=sg_ay_dict["data"]
         )
+
+    elif sg_ay_dict["type"].lower() == "playlist":
+        # TODO: create playlist + add connected versions
+        ay_entity = None
+
     elif sg_ay_dict["type"].lower() == "version":
         # SG doesn't have values for product_name and version (int)
         # we might create some assumption how to parsem out in the future

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -158,6 +158,10 @@ def _sg_to_ay_dict(
         content = sg_entity["content"] or ""
         name = slugify_string(content, min_length=0)
         label = content
+    elif sg_entity["type"] == "Playlist":
+        ay_entity_type = "entity_list"
+        name = slugify_string(sg_entity["code"], min_length=0)
+        label = sg_entity["code"]
     else:
         name = slugify_string(sg_entity["code"], min_length=0)
         label = sg_entity["code"]

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -1508,10 +1508,6 @@ def create_new_ayon_entity(
             data=sg_ay_dict["data"]
         )
 
-    elif sg_ay_dict["type"].lower() == "playlist":
-        # TODO: create playlist + add connected versions
-        ay_entity = None
-
     elif sg_ay_dict["type"].lower() == "version":
         # SG doesn't have values for product_name and version (int)
         # we might create some assumption how to parsem out in the future


### PR DESCRIPTION
## Changelog Description

fixes: #293 

Playlist support was added from events synced on https://github.com/ynput/ayon-shotgrid/pull/277 however feature was missing on manual `SG -> AYON` and `AYON -> SG` manual syncs.

Changes:
* [X] Fixed a few hiccups with playlist sync
* [X] Implemented  `SG -> AYON` and `AYON -> SG` leveraging the same logic as event-based sync.

## Testing notes:
1. Start-up the processor service
2. Create a AYON playlist with some Version in it.
3. Press `AYON> SG`, ensure it get synced to SG (remove/add stuff then re-sync multiple times)
4. Delete playlist in AYON
5. Press `SG > AYON`, ensure it get synced to AYON (remove/add stuff then re-sync multiple times)

