### PR TITLE
Fix attribute inheritance value detection on AYON -> SG sync.

### DIFF
--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -2228,15 +2228,20 @@ def create_new_sg_entity(
             if ay_status and ay_status in get_sg_statuses(sg_session, sg_type):
                 data["sg_status_list"] = ay_status
 
+    attr_values = ay_entity.attribs.to_dict()
     # Fill up data with any extra attributes from AYON we want to sync to SG
-    # Use folder entity to get inherited attribute values.
-    folder_entity = ayon_api.get_folder_by_id(
-        ay_entity.project_name,
-        ay_entity.id,
-    )
+    # If some values are None, that could mean the attribute is inherited from the parent.
+    # Use folder entity to get inherited attribute values then.
+    if None in attr_values:
+        folder_entity = ayon_api.get_folder_by_id(
+            ay_entity.project_name,
+            ay_entity.id,
+        )
+        attr_values = folder_entity["attrib"]
+
     data |= get_sg_custom_attributes_data(
         sg_session,
-        folder_entity["attrib"],
+        attr_values,
         sg_type,
         custom_attribs_map
     )

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -2229,9 +2229,14 @@ def create_new_sg_entity(
                 data["sg_status_list"] = ay_status
 
     # Fill up data with any extra attributes from AYON we want to sync to SG
+    # Use folder entity to get inherited attribute values.
+    folder_entity = ayon_api.get_folder_by_id(
+        ay_entity.project_name,
+        ay_entity.id,
+    )
     data |= get_sg_custom_attributes_data(
         sg_session,
-        ay_entity.attribs.to_dict(),
+        folder_entity["attrib"],
         sg_type,
         custom_attribs_map
     )

--- a/services/shotgrid_common/utils.py
+++ b/services/shotgrid_common/utils.py
@@ -2232,7 +2232,7 @@ def create_new_sg_entity(
     # Fill up data with any extra attributes from AYON we want to sync to SG
     # If some values are None, that could mean the attribute is inherited from the parent.
     # Use folder entity to get inherited attribute values then.
-    if None in attr_values:
+    if None in attr_values.values():
         folder_entity = ayon_api.get_folder_by_id(
             ay_entity.project_name,
             ay_entity.id,


### PR DESCRIPTION
## Changelog Description

fixes: #101 
When a new entity was created on AYON with attributes inheriting values from parent, those values were not reported in SG properly.


## Testing notes:

1. Set up some attribute configuration in your addon settings (e.g. resolution or frame range)

Manual project sync:
1. Create a new folder in AYON with inherited attributes
2. Trigger AYON -> SG
3. Ensure new entity is created and values are reported as static values in SG


Automated sync:
1. Configure automated sync based on events
2. Create a new folder in AYON with inherited attributes
3. Ensure new entity is created and values are reported as static values in SG
