### PR TITLE
Ensure rolling back AYON attribute to inherited parent value reports it in SG

### DIFF
--- a/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
+++ b/services/shotgrid_common/ayon_shotgrid_hub/update_from_ayon.py
@@ -416,6 +416,19 @@ def update_sg_entity_from_ayon_event(
             if "attribs" in new_attribs:
                 new_attribs = new_attribs["attribs"]
 
+            # If attribute value is None, it could be because attribute
+            # got reset to inherit from parent. Gather new values explicitly
+            # from the folder entity.
+            if None in new_attribs.values():
+                folder_entity = ayon_api.get_folder_by_id(
+                    ayon_event["project"],
+                    ayon_event["summary"]["entityId"],
+                )
+                new_attribs = {
+                    key: folder_entity["attrib"].get(key)
+                    for key in new_attribs
+                }
+
         # Label changed
         elif ayon_event["topic"].endswith("label_changed"):
             new_value = ayon_event["payload"].get("newValue")
@@ -476,13 +489,14 @@ def update_sg_entity_from_ayon_event(
             new_attribs = None
 
         if new_attribs:
-            data_to_update.update(get_sg_custom_attributes_data(
-                sg_session,
-                new_attribs,
-                sg_entity_type,
-                custom_attribs_map
-            ))
-
+            data_to_update.update(
+                get_sg_custom_attributes_data(
+                    sg_session,
+                    new_attribs,
+                    sg_entity_type,
+                    custom_attribs_map
+                )
+            )
 
         sg_entity = sg_session.update(
             sg_entity_type,


### PR DESCRIPTION
## Changelog Description

fixes: #298 

Changing an attribute on a Shot, for example, generates an event that triggers the sync of the value to ShotGrid, that all fine. But, if you roll back the value in AYON, inheriting the value from the parent, the value does not change in ShotGrid.

## Testing notes:
1. Configure shotgrid with an automated attribute sync
2. Change value to a folder id -> ensure value is reported to SG
3. Change back value to "inherit from parent" -> ensure value is reported to SG
